### PR TITLE
feat : added module message design and functionality and also fixed bug to make workspace functional

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -35,7 +35,7 @@ const nextConfig = {
       },
     ],
   },
-  transpilePackages: ["gif-picker-react-klipy"],
+  transpilePackages: ["gif-picker-react-klipy", "swiper"],
 };
 
 export default nextConfig;

--- a/src/app/app/workspace/[id]/[moduleId]/page.jsx
+++ b/src/app/app/workspace/[id]/[moduleId]/page.jsx
@@ -6,11 +6,17 @@ import ProtectedRoute from "@/components/auth/ProtectedRoute";
 import WorkspaceSidebar from "@/components/ChatDashboard/WorkspaceSidebar";
 import ChannelSidebar from "@/components/ChatDashboard/ChannelSidebar";
 import WorkspaceSettingsPanel from "@/components/workspace/WorkspaceSettingsPanel";
+import { ModuleProvider } from "@/context/ModuleProvider";
+import ModuleChatWindow from "@/components/workspace/ModuleChatWindow";
+import CreateModuleModal from "@/components/workspace/CreateModuleModal";
 
 export default function ModulePage() {
   const { id, moduleId } = useParams();
   const router = useRouter();
   const [showSettings, setShowSettings] = useState(false);
+  const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+  const [showCreateModule, setShowCreateModule] = useState(false);
+  const [createModuleCategory, setCreateModuleCategory] = useState("General");
 
   // Local state to highlight "Spaces" tab and prevent navigation issues
   const [activeView, setActiveView] = useState("workspace");
@@ -27,22 +33,55 @@ export default function ModulePage() {
         />
 
         <div className="flex flex-1 min-h-0 relative">
-          {/* Channel / Module Sidebar */}
+          {/* Mobile sidebar overlay */}
+          {isSidebarOpen && (
+            <div className="absolute inset-0 z-40 flex md:hidden">
+              <div
+                className="absolute inset-0 bg-black/50"
+                onClick={() => setIsSidebarOpen(false)}
+              />
+              <div className="relative z-50 w-64 shrink-0 bg-obsidian border-r border-white/[0.06]">
+                <ChannelSidebar
+                  selectedWorkspaceId={id}
+                  activeModuleId={moduleId}
+                  onBack={() => router.push("/app/workspace")}
+                  onSettingsOpen={() => {
+                    setIsSidebarOpen(false);
+                    setShowSettings(true);
+                  }}
+                  onCreateModule={(cat) => {
+                    setCreateModuleCategory(cat || "General");
+                    setIsSidebarOpen(false);
+                    setShowCreateModule(true);
+                  }}
+                />
+              </div>
+            </div>
+          )}
+
+          {/* Channel / Module Sidebar — desktop */}
           <div className="hidden md:flex w-64 shrink-0 border-r border-white/[0.06]">
             <ChannelSidebar
               selectedWorkspaceId={id}
               activeModuleId={moduleId}
               onBack={() => router.push("/app/workspace")}
               onSettingsOpen={() => setShowSettings(true)}
-              // onCreateModule wired by Member 6
+              onCreateModule={(cat) => {
+                setCreateModuleCategory(cat || "General");
+                setShowCreateModule(true);
+              }}
             />
           </div>
 
-          {/* Main Chat Area (Member 6 will replace this) */}
-          <div className="flex-1 flex items-center justify-center">
-            <p className="text-ivory/20 text-sm font-display">
-              Module chat will appear here
-            </p>
+          {/* Main Chat Area */}
+          <div className="flex-1 min-w-0">
+            <ModuleProvider moduleId={moduleId} workspaceId={id}>
+              <ModuleChatWindow
+                moduleId={moduleId}
+                workspaceId={id}
+                onToggleSidebar={() => setIsSidebarOpen((v) => !v)}
+              />
+            </ModuleProvider>
           </div>
 
           {/* Workspace Settings Panel */}
@@ -54,6 +93,15 @@ export default function ModulePage() {
           )}
         </div>
       </div>
+
+      {/* Create Module Modal */}
+      {showCreateModule && (
+        <CreateModuleModal
+          workspaceId={id}
+          defaultCategory={createModuleCategory}
+          onClose={() => setShowCreateModule(false)}
+        />
+      )}
     </ProtectedRoute>
   );
 }

--- a/src/app/app/workspace/[id]/page.jsx
+++ b/src/app/app/workspace/[id]/page.jsx
@@ -6,11 +6,14 @@ import ProtectedRoute from "@/components/auth/ProtectedRoute";
 import WorkspaceSidebar from "@/components/ChatDashboard/WorkspaceSidebar";
 import ChannelSidebar from "@/components/ChatDashboard/ChannelSidebar";
 import WorkspaceSettingsPanel from "@/components/workspace/WorkspaceSettingsPanel";
+import CreateModuleModal from "@/components/workspace/CreateModuleModal";
 
 export default function WorkspacePage() {
   const { id } = useParams();
   const router = useRouter();
   const [showSettings, setShowSettings] = useState(false);
+  const [showCreateModule, setShowCreateModule] = useState(false);
+  const [createModuleCategory, setCreateModuleCategory] = useState("General");
 
   return (
     <ProtectedRoute>
@@ -24,11 +27,14 @@ export default function WorkspacePage() {
               selectedWorkspaceId={id}
               onBack={() => router.push("/app/workspace")}
               onSettingsOpen={() => setShowSettings(true)}
-              // onCreateModule wired by Member 6
+              onCreateModule={(cat) => {
+                setCreateModuleCategory(cat || "General");
+                setShowCreateModule(true);
+              }}
             />
           </div>
 
-          {/* Main Content — TODO [Member 6]: Replace with <ModuleChatWindow workspaceId={id} /> */}
+          {/* Main Content — no module selected */}
           <div className="flex-1 flex items-center justify-center">
             <div className="text-center space-y-3">
               <Hash size={40} className="mx-auto text-ivory/10" />
@@ -47,6 +53,15 @@ export default function WorkspacePage() {
           )}
         </div>
       </div>
+
+      {/* Create Module Modal */}
+      {showCreateModule && (
+        <CreateModuleModal
+          workspaceId={id}
+          defaultCategory={createModuleCategory}
+          onClose={() => setShowCreateModule(false)}
+        />
+      )}
     </ProtectedRoute>
   );
 }

--- a/src/components/ChatDashboard/ChannelSidebar.jsx
+++ b/src/components/ChatDashboard/ChannelSidebar.jsx
@@ -98,10 +98,24 @@ export default function ChannelSidebar({
             {workspace?.name || "Workspace"}
           </h2>
         </div>
-        <ChevronDown
-          size={16}
-          className="text-ivory/20 group-hover:text-ivory/60 transition-colors duration-300"
-        />
+        <div className="flex items-center gap-1.5">
+          {(workspace?.myRole === "owner" || workspace?.myRole === "admin") && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onCreateModule?.("General");
+              }}
+              title="New module"
+              className="w-6 h-6 rounded-lg flex items-center justify-center text-ivory/25 hover:text-accent hover:bg-white/6 transition-all duration-200 shrink-0"
+            >
+              <Plus size={14} />
+            </button>
+          )}
+          <ChevronDown
+            size={16}
+            className="text-ivory/20 group-hover:text-ivory/60 transition-colors duration-300"
+          />
+        </div>
         <div className="absolute bottom-0 left-4 right-4 h-px bg-linear-to-r from-transparent via-accent/20 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
       </div>
 
@@ -130,8 +144,9 @@ export default function ChannelSidebar({
                     <button
                       onClick={(e) => {
                         e.stopPropagation();
-                        onCreateModule?.(); // Will be wired later
+                        onCreateModule?.(group.name);
                       }}
+                      title="Add module"
                       className="text-ivory/15 hover:text-accent opacity-0 group-hover/cat:opacity-100 transition-all duration-200"
                     >
                       <Plus size={13} />
@@ -193,9 +208,19 @@ export default function ChannelSidebar({
             {groupedModules.length === 0 && !loadingModules && (
               <div className="text-center py-8 px-4">
                 <Hash size={24} className="mx-auto text-ivory/10 mb-2" />
-                <p className="text-ivory/20 text-[11px] font-mono">
+                <p className="text-ivory/20 text-[11px] font-mono mb-3">
                   No modules yet
                 </p>
+                {(workspace?.myRole === "owner" ||
+                  workspace?.myRole === "admin") && (
+                  <button
+                    onClick={() => onCreateModule?.("General")}
+                    className="flex items-center gap-1.5 mx-auto text-[11px] font-mono text-accent/60 hover:text-accent transition-colors duration-200"
+                  >
+                    <Plus size={12} />
+                    Add a module
+                  </button>
+                )}
               </div>
             )}
           </div>

--- a/src/components/ChatDashboard/ChannelSidebar.jsx
+++ b/src/components/ChatDashboard/ChannelSidebar.jsx
@@ -15,6 +15,9 @@ import {
   FolderPlus,
   Check,
   X,
+  MoreHorizontal,
+  Pencil,
+  Trash2,
 } from "lucide-react";
 import useAuth from "@/hooks/useAuth";
 import { useWorkspace } from "@/hooks/useWorkspace";
@@ -34,12 +37,43 @@ export default function ChannelSidebar({
     fetchModules,
     workspaces,
     addCategory,
+    updateCategory,
+    deleteCategory,
   } = useWorkspace();
   const router = useRouter();
 
   const [showNewCategory, setShowNewCategory] = React.useState(false);
   const [newCategoryName, setNewCategoryName] = React.useState("");
   const [savingCategory, setSavingCategory] = React.useState(false);
+
+  // Per-category menu state
+  const [openMenuCat, setOpenMenuCat] = React.useState(null);
+  const [renamingCat, setRenamingCat] = React.useState(null);
+  const [renameValue, setRenameValue] = React.useState("");
+
+  const handleRenameSubmit = async (e) => {
+    e?.preventDefault();
+    if (!renameValue.trim() || !renamingCat) return;
+    try {
+      await updateCategory(
+        selectedWorkspaceId,
+        renamingCat._id,
+        renameValue.trim(),
+      );
+      setRenamingCat(null);
+    } catch (err) {
+      toast.error(err?.response?.data?.message || "Failed to rename category");
+    }
+  };
+
+  const handleDeleteCategory = async (catEntry) => {
+    if (!catEntry?._id) return;
+    try {
+      await deleteCategory(selectedWorkspaceId, catEntry._id);
+    } catch (err) {
+      toast.error(err?.response?.data?.message || "Failed to delete category");
+    }
+  };
 
   const handleCreateCategory = async (e) => {
     e?.preventDefault();
@@ -88,12 +122,14 @@ export default function ChannelSidebar({
     );
 
     // Build final array in category order (from workspace), extras at end
+    // Always include every workspace category, even empty ones
     const ordered = [];
+    const seenNames = new Set();
     categoryOrder.forEach((name) => {
-      if (groups[name]) {
-        ordered.push({ name, modules: groups[name] });
-        delete groups[name];
-      }
+      if (seenNames.has(name)) return; // skip genuine DB duplicates
+      seenNames.add(name);
+      ordered.push({ name, modules: groups[name] || [] });
+      delete groups[name];
     });
 
     // Add any leftover categories alphabetically
@@ -169,83 +205,174 @@ export default function ChannelSidebar({
           </div>
         ) : (
           <div className="space-y-6">
-            {groupedModules.map((group) => (
-              <div key={group.name}>
-                {/* Category Header */}
-                <div className="flex items-center justify-between px-2 mb-1.5 group/cat cursor-pointer">
-                  <div className="flex items-center gap-1.5">
-                    <span className="w-0.5 h-3 rounded-full bg-accent/30" />
-                    <span className="text-[10px] font-mono font-bold tracking-[0.15em] uppercase text-ivory/25 group-hover/cat:text-ivory/40 transition-colors duration-200">
-                      {group.name}
-                    </span>
-                  </div>
+            {groupedModules.map((group, gi) => {
+              const catEntry = workspace?.categories?.find(
+                (c) => c.name === group.name,
+              );
+              const isMenuOpen = openMenuCat === group.name;
+              const isRenaming = renamingCat && renamingCat.name === group.name;
+              const isAdminOrOwner =
+                workspace?.myRole === "owner" || workspace?.myRole === "admin";
 
-                  {/* + Button to create module (only admin/owner) */}
-                  {(workspace?.myRole === "owner" ||
-                    workspace?.myRole === "admin") && (
-                    <button
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onCreateModule?.(group.name);
-                      }}
-                      title="Add module"
-                      className="text-ivory/15 hover:text-accent opacity-0 group-hover/cat:opacity-100 transition-all duration-200"
-                    >
-                      <Plus size={13} />
-                    </button>
-                  )}
-                </div>
-
-                {/* Module Items */}
-                <div className="space-y-px">
-                  {group.modules.map((mod) => {
-                    const isActive = mod._id === activeModuleId;
-                    const isAnnouncement = mod.type === "announcement";
-                    const Icon = isAnnouncement ? Megaphone : Hash;
-
-                    return (
-                      <div
-                        key={mod._id}
-                        onClick={() =>
-                          router.push(
-                            `/app/workspace/${selectedWorkspaceId}/${mod._id}`,
-                          )
-                        }
-                        className={`flex items-center gap-2.5 px-2 py-[7px] rounded-xl cursor-pointer group/ch transition-all duration-200 relative ${
-                          isActive
-                            ? "bg-white/[0.06] text-ivory backdrop-blur-sm"
-                            : "hover:bg-white/[0.03] text-ivory/30 hover:text-ivory/60"
-                        }`}
-                      >
-                        {isActive && (
-                          <div className="absolute left-0 top-1/2 -translate-y-1/2 w-[3px] h-4 bg-accent rounded-r-full shadow-[0_0_6px_rgba(0,211,187,0.4)]" />
-                        )}
-
-                        <Icon
-                          size={16}
-                          className={
-                            isActive
-                              ? "text-accent shrink-0"
-                              : "text-ivory/15 group-hover/ch:text-accent/60 transition-colors duration-200 shrink-0"
-                          }
-                        />
-                        <span className="text-[13px] font-medium leading-none flex-1 truncate">
-                          {mod.name}
+              return (
+                <div key={`${group.name}-${gi}`}>
+                  {/* Category Header */}
+                  <div className="flex items-center justify-between px-2 mb-1.5 group/cat">
+                    <div className="flex items-center gap-1.5 flex-1 min-w-0">
+                      <span className="w-0.5 h-3 rounded-full bg-accent/30 shrink-0" />
+                      {isRenaming ? (
+                        <form
+                          onSubmit={handleRenameSubmit}
+                          className="flex items-center gap-1 flex-1 min-w-0"
+                        >
+                          <input
+                            autoFocus
+                            type="text"
+                            value={renameValue}
+                            onChange={(e) => setRenameValue(e.target.value)}
+                            maxLength={50}
+                            className="flex-1 min-w-0 bg-white/[0.05] border border-accent/30 rounded-md px-1.5 py-0.5 text-[10px] font-mono text-ivory/80 focus:outline-none focus:border-accent/60"
+                          />
+                          <button
+                            type="submit"
+                            className="text-accent/60 hover:text-accent"
+                            title="Save"
+                          >
+                            <Check size={11} />
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => setRenamingCat(null)}
+                            className="text-ivory/20 hover:text-ivory/50"
+                            title="Cancel"
+                          >
+                            <X size={11} />
+                          </button>
+                        </form>
+                      ) : (
+                        <span className="text-[10px] font-mono font-bold tracking-[0.15em] uppercase text-ivory/25 group-hover/cat:text-ivory/40 transition-colors duration-200 truncate">
+                          {group.name}
                         </span>
-                        {mod.isPrivate && (
-                          <Lock size={11} className="text-ivory/15 shrink-0" />
-                        )}
-                        {mod.unreadCount > 0 && !isActive && (
-                          <span className="text-[10px] font-bold font-mono bg-accent/20 text-accent rounded-full px-1.5 py-0.5 min-w-[18px] text-center">
-                            {mod.unreadCount > 99 ? "99+" : mod.unreadCount}
-                          </span>
+                      )}
+                    </div>
+
+                    {/* Hamburger menu (only admin/owner, hidden when renaming) */}
+                    {isAdminOrOwner && !isRenaming && (
+                      <div className="relative shrink-0">
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setOpenMenuCat(isMenuOpen ? null : group.name);
+                          }}
+                          title="Category options"
+                          className="w-5 h-5 flex items-center justify-center rounded text-ivory/15 hover:text-accent opacity-0 group-hover/cat:opacity-100 transition-all duration-200"
+                        >
+                          <MoreHorizontal size={13} />
+                        </button>
+
+                        {isMenuOpen && (
+                          <>
+                            {/* backdrop to close */}
+                            <div
+                              className="fixed inset-0 z-40"
+                              onClick={() => setOpenMenuCat(null)}
+                            />
+                            <div className="absolute right-0 top-6 z-50 w-44 bg-[#13131c] border border-white/[0.08] rounded-xl shadow-2xl shadow-black/50 overflow-hidden py-1">
+                              <button
+                                onClick={() => {
+                                  setOpenMenuCat(null);
+                                  onCreateModule?.(group.name);
+                                }}
+                                className="w-full flex items-center gap-2.5 px-3 py-2 text-[12px] text-ivory/60 hover:bg-white/[0.05] hover:text-ivory transition-colors"
+                              >
+                                <Plus size={13} className="text-accent/70" />
+                                Add module
+                              </button>
+                              <button
+                                onClick={() => {
+                                  setOpenMenuCat(null);
+                                  setRenamingCat(
+                                    catEntry || { name: group.name },
+                                  );
+                                  setRenameValue(group.name);
+                                }}
+                                className="w-full flex items-center gap-2.5 px-3 py-2 text-[12px] text-ivory/60 hover:bg-white/[0.05] hover:text-ivory transition-colors"
+                              >
+                                <Pencil size={13} className="text-ivory/40" />
+                                Rename category
+                              </button>
+                              <div className="my-1 border-t border-white/[0.06]" />
+                              <button
+                                onClick={() => {
+                                  setOpenMenuCat(null);
+                                  handleDeleteCategory(catEntry);
+                                }}
+                                className="w-full flex items-center gap-2.5 px-3 py-2 text-[12px] text-red-400/80 hover:bg-red-500/[0.08] hover:text-red-400 transition-colors"
+                              >
+                                <Trash2 size={13} />
+                                Delete category
+                              </button>
+                            </div>
+                          </>
                         )}
                       </div>
-                    );
-                  })}
+                    )}
+                  </div>
+
+                  {/* Module Items */}
+                  <div className="space-y-px">
+                    {group.modules.map((mod) => {
+                      const isActive = mod._id === activeModuleId;
+                      const isAnnouncement = mod.type === "announcement";
+                      const Icon = isAnnouncement ? Megaphone : Hash;
+
+                      return (
+                        <div
+                          key={mod._id}
+                          onClick={() =>
+                            router.push(
+                              `/app/workspace/${selectedWorkspaceId}/${mod._id}`,
+                            )
+                          }
+                          className={`flex items-center gap-2.5 px-2 py-[7px] rounded-xl cursor-pointer group/ch transition-all duration-200 relative ${
+                            isActive
+                              ? "bg-white/[0.06] text-ivory backdrop-blur-sm"
+                              : "hover:bg-white/[0.03] text-ivory/30 hover:text-ivory/60"
+                          }`}
+                        >
+                          {isActive && (
+                            <div className="absolute left-0 top-1/2 -translate-y-1/2 w-[3px] h-4 bg-accent rounded-r-full shadow-[0_0_6px_rgba(0,211,187,0.4)]" />
+                          )}
+
+                          <Icon
+                            size={16}
+                            className={
+                              isActive
+                                ? "text-accent shrink-0"
+                                : "text-ivory/15 group-hover/ch:text-accent/60 transition-colors duration-200 shrink-0"
+                            }
+                          />
+                          <span className="text-[13px] font-medium leading-none flex-1 truncate">
+                            {mod.name}
+                          </span>
+                          {mod.isPrivate && (
+                            <Lock
+                              size={11}
+                              className="text-ivory/15 shrink-0"
+                            />
+                          )}
+                          {mod.unreadCount > 0 && !isActive && (
+                            <span className="text-[10px] font-bold font-mono bg-accent/20 text-accent rounded-full px-1.5 py-0.5 min-w-[18px] text-center">
+                              {mod.unreadCount > 99 ? "99+" : mod.unreadCount}
+                            </span>
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
                 </div>
-              </div>
-            ))}
+              );
+            })}
 
             {/* Inline new-category input */}
             {showNewCategory && (

--- a/src/components/ChatDashboard/ChannelSidebar.jsx
+++ b/src/components/ChatDashboard/ChannelSidebar.jsx
@@ -12,9 +12,13 @@ import {
   Settings,
   Megaphone,
   Loader2,
+  FolderPlus,
+  Check,
+  X,
 } from "lucide-react";
 import useAuth from "@/hooks/useAuth";
 import { useWorkspace } from "@/hooks/useWorkspace";
+import toast from "react-hot-toast";
 
 export default function ChannelSidebar({
   selectedWorkspaceId,
@@ -24,9 +28,34 @@ export default function ChannelSidebar({
   onCreateModule, // () => void — opens CreateModuleModal (later by Member 6)
 }) {
   const { user: currentUser } = useAuth();
-  const { modulesCache, loadingModules, fetchModules, workspaces } =
-    useWorkspace();
+  const {
+    modulesCache,
+    loadingModules,
+    fetchModules,
+    workspaces,
+    addCategory,
+  } = useWorkspace();
   const router = useRouter();
+
+  const [showNewCategory, setShowNewCategory] = React.useState(false);
+  const [newCategoryName, setNewCategoryName] = React.useState("");
+  const [savingCategory, setSavingCategory] = React.useState(false);
+
+  const handleCreateCategory = async (e) => {
+    e?.preventDefault();
+    if (!newCategoryName.trim() || savingCategory) return;
+    setSavingCategory(true);
+    try {
+      await addCategory(selectedWorkspaceId, newCategoryName.trim());
+      setNewCategoryName("");
+      setShowNewCategory(false);
+    } catch (err) {
+      const msg = err?.response?.data?.message || "Failed to create category";
+      toast.error(msg);
+    } finally {
+      setSavingCategory(false);
+    }
+  };
 
   // Auto-fetch modules when a workspace is selected
   useEffect(() => {
@@ -100,16 +129,29 @@ export default function ChannelSidebar({
         </div>
         <div className="flex items-center gap-1.5">
           {(workspace?.myRole === "owner" || workspace?.myRole === "admin") && (
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                onCreateModule?.("General");
-              }}
-              title="New module"
-              className="w-6 h-6 rounded-lg flex items-center justify-center text-ivory/25 hover:text-accent hover:bg-white/6 transition-all duration-200 shrink-0"
-            >
-              <Plus size={14} />
-            </button>
+            <div className="flex items-center gap-0.5">
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setShowNewCategory((v) => !v);
+                  setNewCategoryName("");
+                }}
+                title="New category"
+                className="w-6 h-6 rounded-lg flex items-center justify-center text-ivory/25 hover:text-accent hover:bg-white/6 transition-all duration-200 shrink-0"
+              >
+                <FolderPlus size={13} />
+              </button>
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onCreateModule?.("General");
+                }}
+                title="New module"
+                className="w-6 h-6 rounded-lg flex items-center justify-center text-ivory/25 hover:text-accent hover:bg-white/6 transition-all duration-200 shrink-0"
+              >
+                <Plus size={14} />
+              </button>
+            </div>
           )}
           <ChevronDown
             size={16}
@@ -204,6 +246,44 @@ export default function ChannelSidebar({
                 </div>
               </div>
             ))}
+
+            {/* Inline new-category input */}
+            {showNewCategory && (
+              <form
+                onSubmit={handleCreateCategory}
+                className="flex items-center gap-1.5 px-2 py-1"
+              >
+                <span className="w-0.5 h-3 rounded-full bg-accent/30 shrink-0" />
+                <input
+                  autoFocus
+                  type="text"
+                  value={newCategoryName}
+                  onChange={(e) => setNewCategoryName(e.target.value)}
+                  placeholder="Category name…"
+                  maxLength={50}
+                  className="flex-1 bg-white/[0.05] border border-accent/30 rounded-lg px-2 py-1 text-[11px] font-mono text-ivory/80 placeholder:text-ivory/20 focus:outline-none focus:border-accent/60 min-w-0"
+                />
+                <button
+                  type="submit"
+                  disabled={!newCategoryName.trim() || savingCategory}
+                  className="w-6 h-6 rounded-md flex items-center justify-center text-accent/60 hover:text-accent hover:bg-white/6 disabled:opacity-30 transition-all"
+                  title="Create"
+                >
+                  <Check size={12} />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setShowNewCategory(false);
+                    setNewCategoryName("");
+                  }}
+                  className="w-6 h-6 rounded-md flex items-center justify-center text-ivory/20 hover:text-ivory/50 hover:bg-white/6 transition-all"
+                  title="Cancel"
+                >
+                  <X size={12} />
+                </button>
+              </form>
+            )}
 
             {groupedModules.length === 0 && !loadingModules && (
               <div className="text-center py-8 px-4">

--- a/src/components/ChatDashboard/ChatWindow.jsx
+++ b/src/components/ChatDashboard/ChatWindow.jsx
@@ -1215,7 +1215,7 @@ export default function ChatWindow({
 
       <form
         onSubmit={handleSend}
-        className="p-4 relative bg-obsidian/80 backdrop-blur-sm border-t border-white/5"
+        className="p-4 relative z-20 bg-obsidian/80 backdrop-blur-sm border-t border-white/5"
       >
         {replyTo && (
           <div className="absolute bottom-full left-0 right-0 p-3 bg-slate-surface border-t border-accent/30 flex items-center justify-between">

--- a/src/components/workspace/CreateModuleModal.jsx
+++ b/src/components/workspace/CreateModuleModal.jsx
@@ -202,8 +202,8 @@ export default function CreateModuleModal({
               value={category}
               onChange={(e) => setCategory(e.target.value)}
             >
-              {categories.map((cat) => (
-                <option key={cat} value={cat} className="bg-obsidian">
+              {categories.map((cat, i) => (
+                <option key={`${cat}-${i}`} value={cat} className="bg-obsidian">
                   {cat}
                 </option>
               ))}
@@ -225,7 +225,9 @@ export default function CreateModuleModal({
             </div>
             <button
               type="button"
-              aria-label={isPrivate ? "Disable private module" : "Enable private module"}
+              aria-label={
+                isPrivate ? "Disable private module" : "Enable private module"
+              }
               aria-pressed={isPrivate}
               onClick={() => setIsPrivate((v) => !v)}
               className={`relative w-10 h-5 rounded-full border transition-all ${

--- a/src/components/workspace/CreateModuleModal.jsx
+++ b/src/components/workspace/CreateModuleModal.jsx
@@ -1,0 +1,270 @@
+"use client";
+import { useState, useEffect } from "react";
+import { createPortal } from "react-dom";
+import { useRouter } from "next/navigation";
+import { Hash, Megaphone, Lock, X, Loader2 } from "lucide-react";
+import { useWorkspace } from "@/hooks/useWorkspace";
+import toast from "react-hot-toast";
+
+const MODULE_TYPES = [
+  {
+    value: "text",
+    label: "Text",
+    icon: Hash,
+    description: "General-purpose chat channel",
+  },
+  {
+    value: "announcement",
+    label: "Announcement",
+    icon: Megaphone,
+    description: "Admins post, members read",
+  },
+];
+
+function toSlug(name) {
+  return name
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, "-")
+    .replace(/[^a-z0-9-]/g, "");
+}
+
+export default function CreateModuleModal({
+  workspaceId,
+  defaultCategory = "General",
+  onClose,
+}) {
+  const router = useRouter();
+  const { workspaces, createModule } = useWorkspace();
+  const workspace = workspaces.find((w) => w._id === workspaceId);
+  const categories = workspace?.categories
+    ?.map((c) => c.name)
+    .filter(Boolean) || ["General"];
+
+  const [name, setName] = useState("");
+  const [type, setType] = useState("text");
+  const [category, setCategory] = useState(
+    categories.includes(defaultCategory)
+      ? defaultCategory
+      : categories[0] || "General",
+  );
+  const [isPrivate, setIsPrivate] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+    return () => setMounted(false);
+  }, []);
+
+  // Sync category when defaultCategory or workspace categories resolve
+  useEffect(() => {
+    if (categories.length > 0) {
+      setCategory(
+        categories.includes(defaultCategory) ? defaultCategory : categories[0],
+      );
+    }
+  }, [defaultCategory, workspaceId]);
+
+  // Close on Escape
+  useEffect(() => {
+    const onKey = (e) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  const slug = toSlug(name);
+  const canSubmit = slug.length > 0 && !submitting;
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!canSubmit) return;
+    setSubmitting(true);
+    try {
+      const mod = await createModule(workspaceId, {
+        name: slug,
+        type,
+        category,
+        isPrivate,
+      });
+      toast.success(`#${mod.name} created!`);
+      onClose();
+      router.push(`/app/workspace/${workspaceId}/${mod._id}`);
+    } catch (err) {
+      toast.error(err?.response?.data?.message || "Failed to create module");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (!mounted || typeof window === "undefined") return null;
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      {/* Backdrop */}
+      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" />
+
+      {/* Modal */}
+      <div className="relative w-full max-w-md bg-obsidian border border-white/[0.08] rounded-2xl shadow-2xl overflow-hidden">
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 pt-5 pb-4 border-b border-white/[0.06]">
+          <div>
+            <h2 className="text-ivory font-display font-bold text-[15px]">
+              Create Module
+            </h2>
+            <p className="text-ivory/30 text-[11px] font-mono mt-0.5">
+              in {workspace?.name || "workspace"}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="w-8 h-8 rounded-xl flex items-center justify-center text-ivory/25 hover:text-ivory hover:bg-white/[0.06] transition-all"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="px-5 py-5 space-y-5">
+          {/* Module Type */}
+          <div className="space-y-2">
+            <label className="text-[11px] font-mono font-bold text-ivory/40 uppercase tracking-wider">
+              Type
+            </label>
+            <div className="grid grid-cols-2 gap-2">
+              {MODULE_TYPES.map(({ value, label, icon: Icon, description }) => (
+                <button
+                  key={value}
+                  type="button"
+                  onClick={() => setType(value)}
+                  className={`flex flex-col items-start gap-1.5 p-3 rounded-xl border transition-all text-left ${
+                    type === value
+                      ? "bg-accent/10 border-accent/40 text-ivory"
+                      : "bg-white/[0.03] border-white/[0.06] text-ivory/50 hover:border-white/[0.12] hover:text-ivory/70"
+                  }`}
+                >
+                  <Icon
+                    size={16}
+                    className={type === value ? "text-accent" : "text-ivory/30"}
+                  />
+                  <div>
+                    <p className="text-[12px] font-display font-bold leading-none">
+                      {label}
+                    </p>
+                    <p className="text-[10px] font-mono text-ivory/25 mt-0.5">
+                      {description}
+                    </p>
+                  </div>
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Module Name */}
+          <div className="space-y-1.5">
+            <label className="text-[11px] font-mono font-bold text-ivory/40 uppercase tracking-wider">
+              Name
+            </label>
+            <div className="flex items-center gap-2 bg-white/[0.04] border border-white/[0.06] rounded-xl px-3 py-2.5 focus-within:border-accent/30 transition-all">
+              <Hash size={14} className="text-ivory/20 shrink-0" />
+              <input
+                type="text"
+                className="flex-1 bg-transparent text-ivory text-[13px] outline-none placeholder:text-ivory/20 font-mono"
+                placeholder="e.g. general-chat"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                maxLength={80}
+                autoFocus
+              />
+            </div>
+            {slug && (
+              <p className="text-[10px] font-mono text-ivory/25 px-1">
+                Will be created as{" "}
+                <span className="text-accent/60">#{slug}</span>
+              </p>
+            )}
+          </div>
+
+          {/* Category */}
+          <div className="space-y-1.5">
+            <label className="text-[11px] font-mono font-bold text-ivory/40 uppercase tracking-wider">
+              Category
+            </label>
+            <select
+              className="w-full bg-white/[0.04] border border-white/[0.06] rounded-xl px-3 py-2.5 text-ivory text-[13px] font-mono outline-none focus:border-accent/30 transition-all appearance-none cursor-pointer"
+              value={category}
+              onChange={(e) => setCategory(e.target.value)}
+            >
+              {categories.map((cat) => (
+                <option key={cat} value={cat} className="bg-obsidian">
+                  {cat}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Private toggle */}
+          <div className="flex items-center justify-between bg-white/[0.03] border border-white/[0.06] rounded-xl px-4 py-3">
+            <div className="flex items-center gap-2.5">
+              <Lock size={15} className="text-ivory/30" />
+              <div>
+                <p className="text-[12px] font-display font-bold text-ivory/70">
+                  Private module
+                </p>
+                <p className="text-[10px] font-mono text-ivory/25">
+                  Only invited members can view
+                </p>
+              </div>
+            </div>
+            <button
+              type="button"
+              aria-label={isPrivate ? "Disable private module" : "Enable private module"}
+              aria-pressed={isPrivate}
+              onClick={() => setIsPrivate((v) => !v)}
+              className={`relative w-10 h-5 rounded-full border transition-all ${
+                isPrivate
+                  ? "bg-accent/30 border-accent/40"
+                  : "bg-white/[0.06] border-white/[0.10]"
+              }`}
+            >
+              <span
+                className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full transition-transform ${
+                  isPrivate
+                    ? "translate-x-5 bg-accent"
+                    : "translate-x-0 bg-ivory/30"
+                }`}
+              />
+            </button>
+          </div>
+
+          {/* Footer */}
+          <div className="flex gap-2 pt-1">
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex-1 py-2.5 rounded-xl text-[12px] font-mono font-bold text-ivory/30 hover:text-ivory bg-white/[0.03] hover:bg-white/[0.06] border border-white/[0.06] transition-all"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={!canSubmit}
+              className="flex-1 py-2.5 rounded-xl text-[12px] font-mono font-bold text-accent bg-accent/10 hover:bg-accent/20 border border-accent/20 transition-all disabled:opacity-30 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+            >
+              {submitting && <Loader2 size={13} className="animate-spin" />}
+              Create Module
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/components/workspace/ModuleChatWindow.jsx
+++ b/src/components/workspace/ModuleChatWindow.jsx
@@ -1,0 +1,782 @@
+"use client";
+import React, { useState, useEffect, useRef, useCallback } from "react";
+import Image from "next/image";
+import dynamic from "next/dynamic";
+import {
+  Hash,
+  Megaphone,
+  Smile,
+  Send,
+  Reply,
+  Pencil,
+  Trash2,
+  ChevronDown,
+  Loader2,
+  Menu,
+  X,
+} from "lucide-react";
+import useAuth from "@/hooks/useAuth";
+import { useModule } from "@/hooks/useModule";
+import { useWorkspace } from "@/hooks/useWorkspace";
+import { EMOJI_MAP } from "@/utils/emojis";
+import { getGroupInitials, getGroupAvatarColor } from "@/utils/groupAvatar";
+import toast from "react-hot-toast";
+
+const EmojiPicker = dynamic(() => import("emoji-picker-react"), { ssr: false });
+const GifPicker = dynamic(
+  () =>
+    import("gif-picker-react-klipy").then((m) => m.GifPicker || m.default || m),
+  { ssr: false },
+);
+
+const getDateLabel = (dateStr) => {
+  const date = new Date(dateStr);
+  const today = new Date();
+  const yesterday = new Date();
+  yesterday.setDate(today.getDate() - 1);
+  const isSame = (a, b) =>
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate();
+  if (isSame(date, today)) return "Today";
+  if (isSame(date, yesterday)) return "Yesterday";
+  return date.toLocaleDateString([], {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
+};
+
+const toDateKey = (d) => {
+  const date = new Date(d);
+  return `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`;
+};
+
+export default function ModuleChatWindow({
+  moduleId,
+  workspaceId,
+  onToggleSidebar,
+}) {
+  const { user } = useAuth();
+  const { workspaces, modulesCache } = useWorkspace();
+  const {
+    messages,
+    loading,
+    hasMore,
+    loadMore,
+    reactions,
+    typingUsers,
+    sendMessage,
+    sendTyping,
+    reactToMessage,
+    editMessage,
+    deleteMessage,
+  } = useModule();
+
+  const workspace = workspaces.find((w) => w._id === workspaceId);
+  const modules = modulesCache[workspaceId] || [];
+  const activeModule = modules.find((m) => m._id === moduleId);
+  const isAnnouncement = activeModule?.type === "announcement";
+  const isAdminOrOwner =
+    workspace?.myRole === "owner" || workspace?.myRole === "admin";
+
+  // ── Local UI state ────────────────────────────────────────────────────────
+  const [text, setText] = useState("");
+  const [replyTo, setReplyTo] = useState(null);
+  const [editingId, setEditingId] = useState(null);
+  const [editedText, setEditedText] = useState("");
+  const [suggestions, setSuggestions] = useState([]);
+  const [suggestionIndex, setSuggestionIndex] = useState(0);
+  const [reactionPickerMsgId, setReactionPickerMsgId] = useState(null);
+  const [showEmojiPicker, setShowEmojiPicker] = useState(false);
+  const [showGifPicker, setShowGifPicker] = useState(false);
+  const [longPressedMsgId, setLongPressedMsgId] = useState(null);
+
+  const bottomRef = useRef(null);
+  const reactionPickerRef = useRef(null);
+  const emojiPickerRef = useRef(null);
+  const gifPickerRef = useRef(null);
+  const longPressTimer = useRef(null);
+
+  // Auto-scroll to bottom on new messages
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages]);
+
+  // Reset input state when module changes
+  useEffect(() => {
+    setText("");
+    setReplyTo(null);
+    setEditingId(null);
+    setSuggestions([]);
+    setReactionPickerMsgId(null);
+    setShowEmojiPicker(false);
+    setShowGifPicker(false);
+  }, [moduleId]);
+
+  // Close pickers on outside click
+  useEffect(() => {
+    const onDown = (e) => {
+      if (
+        reactionPickerRef.current &&
+        !reactionPickerRef.current.contains(e.target)
+      ) {
+        setReactionPickerMsgId(null);
+      }
+      if (
+        emojiPickerRef.current &&
+        !emojiPickerRef.current.contains(e.target)
+      ) {
+        setShowEmojiPicker(false);
+      }
+      if (gifPickerRef.current && !gifPickerRef.current.contains(e.target)) {
+        setShowGifPicker(false);
+      }
+      if (longPressedMsgId) setLongPressedMsgId(null);
+    };
+    if (
+      reactionPickerMsgId ||
+      showEmojiPicker ||
+      showGifPicker ||
+      longPressedMsgId
+    ) {
+      document.addEventListener("mousedown", onDown);
+    }
+    return () => document.removeEventListener("mousedown", onDown);
+  }, [reactionPickerMsgId, showEmojiPicker, showGifPicker, longPressedMsgId]);
+
+  // ── Long-press (mobile) ───────────────────────────────────────────────────
+  const handleTouchStart = useCallback((msgId) => {
+    longPressTimer.current = setTimeout(() => {
+      setLongPressedMsgId(msgId);
+      if (navigator.vibrate) navigator.vibrate(30);
+    }, 500);
+  }, []);
+
+  const handleTouchEnd = useCallback(() => {
+    if (longPressTimer.current) clearTimeout(longPressTimer.current);
+  }, []);
+
+  // ── Text change + typing + emoji autocomplete ─────────────────────────────
+  const handleTextChange = (e) => {
+    let val = e.target.value;
+    const lastWord = val.split(" ").pop();
+    if (EMOJI_MAP[lastWord]) val = val.replace(lastWord, EMOJI_MAP[lastWord]);
+    setText(val);
+    sendTyping(val.trim().length > 0);
+
+    const match = val.match(/:([a-zA-Z0-9_]*)$/);
+    if (match) {
+      const q = match[1].toLowerCase();
+      const filtered = Object.entries(EMOJI_MAP)
+        .filter(([code]) => {
+          const name = code.slice(1, -1);
+          return (
+            name.startsWith(q) || name.split("_").some((w) => w.startsWith(q))
+          );
+        })
+        .sort(([a], [b]) => a.localeCompare(b))
+        .slice(0, 8);
+      setSuggestions(filtered);
+      setSuggestionIndex(0);
+    } else {
+      setSuggestions([]);
+    }
+  };
+
+  const insertEmoji = (emoji) => {
+    setText((prev) => {
+      const match = prev.match(/:[a-zA-Z0-9_]*$/);
+      if (!match) return prev + emoji;
+      return prev.slice(0, match.index) + emoji;
+    });
+    setSuggestions([]);
+  };
+
+  const handleKeyDown = (e) => {
+    if (suggestions.length > 0) {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setSuggestionIndex((p) => (p + 1) % suggestions.length);
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setSuggestionIndex(
+          (p) => (p - 1 + suggestions.length) % suggestions.length,
+        );
+      } else if (e.key === "Enter") {
+        e.preventDefault();
+        insertEmoji(suggestions[suggestionIndex][1]);
+      } else if (e.key === "Escape") {
+        setSuggestions([]);
+      }
+    }
+  };
+
+  // ── Send ──────────────────────────────────────────────────────────────────
+  const handleSend = (e) => {
+    e.preventDefault();
+    if (!text.trim()) return;
+    if (isAnnouncement && !isAdminOrOwner) return;
+    sendMessage({ text: text.trim(), replyTo });
+    setText("");
+    setReplyTo(null);
+    setSuggestions([]);
+    sendTyping(false);
+  };
+
+  // ── GIF ───────────────────────────────────────────────────────────────────
+  const handleGifClick = (gif) => {
+    const gifUrl = gif.url || gif.previewUrl;
+    sendMessage({ gifUrl });
+    setShowGifPicker(false);
+  };
+
+  // ── Edit ──────────────────────────────────────────────────────────────────
+  const handleEditSave = () => {
+    if (!editedText.trim()) return;
+    editMessage(editingId, editedText.trim());
+    setEditingId(null);
+    setEditedText("");
+  };
+
+  // ── Delete (always for everyone in modules) ───────────────────────────────
+  const handleDelete = (msgId) => {
+    deleteMessage(msgId, true);
+  };
+
+  // ── Empty state ───────────────────────────────────────────────────────────
+  if (!activeModule) {
+    return (
+      <div className="flex-1 bg-obsidian flex flex-col items-center justify-center gap-5 p-6">
+        <div className="w-16 h-16 rounded-3xl bg-accent/10 border border-accent/20 flex items-center justify-center">
+          <Hash size={28} className="text-accent/40" />
+        </div>
+        <div className="text-center space-y-1.5">
+          <h2 className="text-ivory font-display font-bold">Select a module</h2>
+          <p className="text-ivory/30 text-sm max-w-[220px]">
+            Choose a module from the sidebar to start chatting
+          </p>
+        </div>
+        <button
+          onClick={onToggleSidebar}
+          className="md:hidden px-4 py-2.5 bg-accent/10 hover:bg-accent/20 border border-accent/20 rounded-xl text-accent text-sm font-bold transition-all"
+        >
+          Open Modules
+        </button>
+      </div>
+    );
+  }
+
+  const ModuleIcon = isAnnouncement ? Megaphone : Hash;
+  const canType = !isAnnouncement || isAdminOrOwner;
+
+  return (
+    <main className="flex-1 min-w-0 flex flex-col bg-obsidian relative h-full">
+      {/* ── Header ──────────────────────────────────────────────────────────── */}
+      <header className="h-14 border-b border-white/[0.06] flex items-center justify-between px-4 bg-obsidian/80 backdrop-blur-sm shrink-0">
+        <div className="flex items-center gap-2.5">
+          <button
+            onClick={onToggleSidebar}
+            className="md:hidden w-8 h-8 rounded-xl bg-white/[0.04] flex items-center justify-center text-ivory/30 hover:text-ivory transition-colors"
+          >
+            <Menu size={18} />
+          </button>
+          <ModuleIcon size={17} className="text-accent/60 shrink-0" />
+          <div>
+            <h2 className="text-ivory font-display font-bold text-[14px] leading-tight">
+              {activeModule.name}
+            </h2>
+            <p className="text-ivory/25 text-[10px] font-mono">
+              {workspace?.name}
+              {isAnnouncement && " · Announcement"}
+            </p>
+          </div>
+        </div>
+      </header>
+
+      {/* ── Message List ──────────────────────────────────────────────────────── */}
+      <div className="flex-1 overflow-y-auto px-3 sm:px-5 py-5 flex flex-col gap-3 scrollbar-hide">
+        {/* Load more button */}
+        {hasMore && (
+          <button
+            onClick={loadMore}
+            disabled={loading}
+            className="self-center px-4 py-1.5 rounded-full text-[11px] font-mono text-ivory/30 hover:text-accent border border-white/[0.06] hover:border-accent/30 transition-all flex items-center gap-1.5"
+          >
+            {loading ? (
+              <Loader2 size={12} className="animate-spin" />
+            ) : (
+              <ChevronDown size={12} />
+            )}
+            Load earlier messages
+          </button>
+        )}
+
+        {loading && messages.length === 0 && (
+          <div className="flex items-center justify-center gap-2 mt-8">
+            <Loader2 size={16} className="text-accent/40 animate-spin" />
+            <p className="text-ivory/20 text-xs font-mono">
+              Loading messages...
+            </p>
+          </div>
+        )}
+
+        {!loading && messages.length === 0 && (
+          <div className="flex flex-col items-center justify-center flex-1 gap-3">
+            <div className="w-12 h-12 rounded-3xl bg-accent/10 border border-accent/15 flex items-center justify-center">
+              <ModuleIcon size={22} className="text-accent/40" />
+            </div>
+            <p className="text-ivory/20 text-xs font-mono">
+              {isAnnouncement
+                ? "No announcements yet."
+                : "Be the first to say something!"}
+            </p>
+          </div>
+        )}
+
+        {/* Date-separated message list */}
+        {messages.map((msg, index) => {
+          const isMe = msg.sender?._id === user?._id;
+          const isGif = !!msg.gifUrl;
+          const currentKey = toDateKey(msg.createdAt);
+          const prevKey =
+            index > 0 ? toDateKey(messages[index - 1].createdAt) : null;
+          const showDate = currentKey !== prevKey;
+
+          return (
+            <React.Fragment key={msg._id}>
+              {showDate && (
+                <div className="flex items-center gap-3 my-2">
+                  <div className="flex-1 h-px bg-white/[0.05]" />
+                  <span className="text-[10px] font-mono text-ivory/20 px-3 py-1 rounded-full bg-white/[0.04] border border-white/[0.06] shrink-0">
+                    {getDateLabel(msg.createdAt)}
+                  </span>
+                  <div className="flex-1 h-px bg-white/[0.05]" />
+                </div>
+              )}
+
+              <div
+                className="flex items-start gap-2.5 group"
+                onTouchStart={() => handleTouchStart(msg._id)}
+                onTouchEnd={handleTouchEnd}
+                onTouchMove={handleTouchEnd}
+              >
+                {/* Sender avatar — always shown in modules */}
+                <div className="w-8 h-8 rounded-xl overflow-hidden shrink-0 mt-0.5 ring-1 ring-white/[0.06]">
+                  <Image
+                    src={
+                      msg.sender?.avatar ||
+                      `https://api.dicebear.com/7.x/avataaars/svg?seed=${msg.sender?.name || "user"}`
+                    }
+                    width={32}
+                    height={32}
+                    className="rounded-xl"
+                    alt={msg.sender?.name || ""}
+                    unoptimized
+                  />
+                </div>
+
+                <div className="flex-1 min-w-0">
+                  {/* Sender name + timestamp */}
+                  <div className="flex items-baseline gap-2 mb-1">
+                    <span
+                      className={`text-[13px] font-display font-bold leading-none ${
+                        isMe ? "text-accent/80" : "text-ivory/70"
+                      }`}
+                    >
+                      {isMe ? "You" : msg.sender?.name || "Member"}
+                    </span>
+                    <span className="text-[10px] font-mono text-ivory/20">
+                      {new Date(msg.createdAt).toLocaleTimeString([], {
+                        hour: "2-digit",
+                        minute: "2-digit",
+                      })}
+                    </span>
+                    {msg.isEdited && (
+                      <span className="text-[9px] font-mono text-ivory/15">
+                        (edited)
+                      </span>
+                    )}
+                  </div>
+
+                  {/* Message bubble */}
+                  <div className="relative group/bubble">
+                    {/* Action toolbar (hover / long-press) */}
+                    {!msg.isOptimistic && !msg.isDeleted && (
+                      <div
+                        className={`absolute -top-7 left-0 items-center gap-0.5 bg-deep border border-white/[0.06] rounded-lg p-0.5 shadow-xl z-30 ${
+                          longPressedMsgId === msg._id
+                            ? "flex"
+                            : "hidden group-hover/bubble:flex"
+                        }`}
+                      >
+                        {/* Quick reactions */}
+                        {["👍", "❤️", "😂", "😮", "😢"].map((emoji) => (
+                          <button
+                            key={emoji}
+                            type="button"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              reactToMessage(msg._id, emoji);
+                              setLongPressedMsgId(null);
+                            }}
+                            className={`p-1.5 rounded-md text-sm transition-all hover:bg-white/[0.06] hover:scale-125 ${
+                              reactions[msg._id]?.[emoji]?.includes(user?._id)
+                                ? "bg-accent/20"
+                                : ""
+                            }`}
+                          >
+                            {emoji}
+                          </button>
+                        ))}
+                        <div className="w-px h-5 bg-white/[0.06] mx-0.5" />
+                        {/* Full emoji picker trigger */}
+                        <button
+                          type="button"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setReactionPickerMsgId(
+                              reactionPickerMsgId === msg._id ? null : msg._id,
+                            );
+                            setLongPressedMsgId(null);
+                          }}
+                          className="p-1.5 rounded-md text-ivory/40 hover:text-accent hover:bg-white/[0.06] transition-all"
+                        >
+                          <Smile size={14} />
+                        </button>
+                        {/* Reply */}
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setReplyTo(msg);
+                            setLongPressedMsgId(null);
+                          }}
+                          className="p-1.5 rounded-md text-ivory/40 hover:text-accent hover:bg-white/[0.06] transition-all"
+                        >
+                          <Reply size={14} />
+                        </button>
+                        {/* Edit / Delete (own messages only) */}
+                        {isMe && (
+                          <>
+                            <div className="w-px h-5 bg-white/[0.06] mx-0.5" />
+                            <button
+                              type="button"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                setEditingId(msg._id);
+                                setEditedText(msg.text || "");
+                                setLongPressedMsgId(null);
+                              }}
+                              className="p-1.5 rounded-md text-blue-400 hover:text-blue-300 hover:bg-blue-500/20 transition-all"
+                            >
+                              <Pencil size={14} />
+                            </button>
+                            <button
+                              type="button"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleDelete(msg._id);
+                                setLongPressedMsgId(null);
+                              }}
+                              className="p-1.5 rounded-md text-red-400 hover:text-red-300 hover:bg-red-500/20 transition-all"
+                            >
+                              <Trash2 size={14} />
+                            </button>
+                          </>
+                        )}
+                      </div>
+                    )}
+
+                    {/* Full emoji reaction picker */}
+                    {reactionPickerMsgId === msg._id && (
+                      <div
+                        ref={reactionPickerRef}
+                        className="absolute top-6 left-0 z-40"
+                      >
+                        <EmojiPicker
+                          onEmojiClick={(emojiData) => {
+                            reactToMessage(msg._id, emojiData.emoji);
+                            setReactionPickerMsgId(null);
+                          }}
+                          theme="dark"
+                          height={340}
+                          width={300}
+                        />
+                      </div>
+                    )}
+
+                    {/* Message content */}
+                    {editingId === msg._id ? (
+                      <div className="flex flex-col gap-2 bg-slate-surface rounded-2xl p-3 border border-accent/40 max-w-lg">
+                        <span className="text-[10px] font-mono font-bold text-accent uppercase tracking-wider">
+                          Editing
+                        </span>
+                        <textarea
+                          className="w-full min-h-16 bg-deep text-ivory text-[13px] px-3 py-2 rounded-xl border border-white/[0.08] focus:outline-none focus:border-accent resize-none scrollbar-hide"
+                          value={editedText}
+                          onChange={(e) => setEditedText(e.target.value)}
+                          onKeyDown={(e) => {
+                            if (e.key === "Enter" && !e.shiftKey) {
+                              e.preventDefault();
+                              handleEditSave();
+                            }
+                            if (e.key === "Escape") {
+                              setEditingId(null);
+                              setEditedText("");
+                            }
+                          }}
+                          autoFocus
+                        />
+                        <div className="flex gap-2 justify-end">
+                          <button
+                            onClick={() => {
+                              setEditingId(null);
+                              setEditedText("");
+                            }}
+                            className="px-3 py-1.5 text-[11px] font-mono text-ivory/30 hover:text-ivory transition-colors rounded-lg hover:bg-white/[0.04]"
+                          >
+                            Cancel (Esc)
+                          </button>
+                          <button
+                            onClick={handleEditSave}
+                            className="px-3 py-1.5 text-[11px] font-mono text-accent bg-accent/10 hover:bg-accent/20 rounded-lg border border-accent/20 transition-all"
+                          >
+                            Save (Enter)
+                          </button>
+                        </div>
+                      </div>
+                    ) : msg.isDeleted ? (
+                      <p className="italic text-ivory/20 text-[12px] font-mono">
+                        This message was deleted
+                      </p>
+                    ) : isGif ? (
+                      <div className="rounded-2xl overflow-hidden max-w-[260px]">
+                        <img
+                          src={msg.gifUrl}
+                          alt="gif"
+                          className="w-full h-auto rounded-2xl"
+                        />
+                      </div>
+                    ) : (
+                      <div
+                        className={`inline-block px-3.5 py-2.5 rounded-2xl rounded-tl-none text-[13px] leading-relaxed max-w-prose ${
+                          isMe
+                            ? "bg-accent/15 text-ivory border border-accent/20"
+                            : "bg-white/[0.04] text-ivory/80 border border-white/[0.06]"
+                        } ${msg.isOptimistic ? "opacity-60" : ""}`}
+                      >
+                        {msg.replyTo && (
+                          <div className="mb-2 p-2 bg-black/20 rounded-lg border-l-2 border-accent/50 text-[11px] opacity-80 line-clamp-2">
+                            <p className="font-bold mb-0.5 text-accent/70">
+                              {msg.replyTo.sender?.name || "Member"}
+                            </p>
+                            {msg.replyTo.text}
+                          </div>
+                        )}
+                        {msg.text}
+                      </div>
+                    )}
+
+                    {/* Reaction pills */}
+                    {reactions[msg._id] &&
+                      Object.entries(reactions[msg._id]).some(
+                        ([, users]) => users.length > 0,
+                      ) && (
+                        <div className="flex flex-wrap gap-1 mt-1.5">
+                          {Object.entries(reactions[msg._id])
+                            .filter(([, users]) => users.length > 0)
+                            .map(([emoji, users]) => (
+                              <button
+                                key={emoji}
+                                onClick={() => reactToMessage(msg._id, emoji)}
+                                className={`flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] border transition-all ${
+                                  users.includes(user?._id)
+                                    ? "bg-accent/20 border-accent/30 text-accent"
+                                    : "bg-white/[0.04] border-white/[0.08] text-ivory/50 hover:border-white/[0.15]"
+                                }`}
+                              >
+                                {emoji}
+                                <span className="font-mono font-bold">
+                                  {users.length}
+                                </span>
+                              </button>
+                            ))}
+                        </div>
+                      )}
+                  </div>
+                </div>
+              </div>
+            </React.Fragment>
+          );
+        })}
+
+        {/* Typing indicator */}
+        {typingUsers.length > 0 && (
+          <div className="flex items-center gap-2 px-1">
+            <div className="flex gap-0.5">
+              {[0, 1, 2].map((i) => (
+                <div
+                  key={i}
+                  className="w-1.5 h-1.5 rounded-full bg-accent/50 animate-bounce"
+                  style={{ animationDelay: `${i * 120}ms` }}
+                />
+              ))}
+            </div>
+            <span className="text-[11px] font-mono text-ivory/25">
+              {typingUsers.length === 1
+                ? `${typingUsers[0].name} is typing...`
+                : `${typingUsers.map((u) => u.name).join(", ")} are typing...`}
+            </span>
+          </div>
+        )}
+
+        <div ref={bottomRef} />
+      </div>
+
+      {/* ── Reply Banner ──────────────────────────────────────────────────────── */}
+      {replyTo && (
+        <div className="mx-4 mb-1 px-3 py-2 bg-white/[0.03] border border-white/[0.06] rounded-xl flex items-center justify-between gap-2">
+          <div className="min-w-0">
+            <p className="text-[10px] font-mono text-accent/70 font-bold mb-0.5">
+              Replying to {replyTo.sender?.name || "Member"}
+            </p>
+            <p className="text-ivory/30 text-[11px] truncate">{replyTo.text}</p>
+          </div>
+          <button
+            onClick={() => setReplyTo(null)}
+            className="w-6 h-6 rounded-lg flex items-center justify-center text-ivory/20 hover:text-ivory/50 hover:bg-white/[0.06] shrink-0 transition-all"
+          >
+            <X size={13} />
+          </button>
+        </div>
+      )}
+
+      {/* ── Input Area ────────────────────────────────────────────────────────── */}
+      {canType ? (
+        <form
+          onSubmit={handleSend}
+          className="mx-3 mb-3 flex items-end gap-2 relative"
+        >
+          {/* Emoji autocomplete suggestions */}
+          {suggestions.length > 0 && (
+            <div className="absolute bottom-full left-0 mb-2 flex flex-wrap gap-1 bg-deep border border-white/[0.08] rounded-xl p-2 shadow-xl max-w-[320px] z-20">
+              {suggestions.map(([code, emoji], i) => (
+                <button
+                  key={code}
+                  type="button"
+                  onClick={() => insertEmoji(emoji)}
+                  className={`px-2 py-1 rounded-lg text-sm transition-all hover:bg-white/[0.06] ${
+                    i === suggestionIndex
+                      ? "bg-accent/20 ring-1 ring-accent/30"
+                      : ""
+                  }`}
+                >
+                  {emoji}{" "}
+                  <span className="text-[10px] font-mono text-ivory/30">
+                    {code}
+                  </span>
+                </button>
+              ))}
+            </div>
+          )}
+
+          {/* Emoji Picker */}
+          {showEmojiPicker && (
+            <div
+              ref={emojiPickerRef}
+              className="absolute bottom-full left-0 mb-2 z-30"
+            >
+              <EmojiPicker
+                onEmojiClick={(data) => {
+                  setText((p) => p + data.emoji);
+                  setShowEmojiPicker(false);
+                }}
+                theme="dark"
+                height={340}
+                width={300}
+              />
+            </div>
+          )}
+
+          {/* GIF Picker */}
+          {showGifPicker && (
+            <div
+              ref={gifPickerRef}
+              className="absolute bottom-full left-0 mb-2 z-30"
+            >
+              <GifPicker
+                onGifClick={handleGifClick}
+                tenorApiKey={process.env.NEXT_PUBLIC_TENOR_API_KEY}
+                theme="dark"
+                width={300}
+                height={380}
+              />
+            </div>
+          )}
+
+          {/* GIF button */}
+          <button
+            type="button"
+            onClick={() => {
+              setShowGifPicker((v) => !v);
+              setShowEmojiPicker(false);
+            }}
+            className="w-9 h-9 shrink-0 rounded-xl bg-white/[0.04] border border-white/[0.06] flex items-center justify-center text-ivory/25 hover:text-accent hover:border-accent/30 transition-all text-[10px] font-bold font-mono"
+          >
+            GIF
+          </button>
+
+          <div className="flex-1 flex items-end gap-2 bg-white/[0.04] border border-white/[0.06] rounded-2xl px-3 py-2.5 focus-within:border-accent/30 transition-all">
+            <textarea
+              className="flex-1 bg-transparent text-ivory text-[13px] resize-none outline-none placeholder:text-ivory/20 font-mono max-h-32 scrollbar-hide leading-relaxed"
+              placeholder={
+                isAnnouncement
+                  ? `Post an announcement in #${activeModule.name}...`
+                  : `Message #${activeModule.name}`
+              }
+              value={text}
+              onChange={handleTextChange}
+              onKeyDown={(e) => {
+                handleKeyDown(e);
+                if (e.key === "Enter" && !e.shiftKey && !suggestions.length) {
+                  e.preventDefault();
+                  handleSend(e);
+                }
+              }}
+              rows={1}
+              onInput={(e) => {
+                e.target.style.height = "auto";
+                e.target.style.height =
+                  Math.min(e.target.scrollHeight, 128) + "px";
+              }}
+            />
+            <button
+              type="button"
+              onClick={() => {
+                setShowEmojiPicker((v) => !v);
+                setShowGifPicker(false);
+              }}
+              className="w-7 h-7 rounded-xl flex items-center justify-center text-ivory/20 hover:text-accent transition-colors shrink-0"
+            >
+              <Smile size={16} />
+            </button>
+          </div>
+
+          <button
+            type="submit"
+            disabled={!text.trim()}
+            className="w-9 h-9 shrink-0 rounded-xl bg-accent/15 hover:bg-accent/25 border border-accent/20 flex items-center justify-center text-accent transition-all disabled:opacity-30 disabled:cursor-not-allowed"
+          >
+            <Send size={15} />
+          </button>
+        </form>
+      ) : (
+        <div className="mx-3 mb-3 px-4 py-3 bg-white/[0.03] border border-white/[0.06] rounded-2xl text-center">
+          <p className="text-ivory/20 text-[12px] font-mono">
+            Only admins and owners can post in announcement modules
+          </p>
+        </div>
+      )}
+    </main>
+  );
+}

--- a/src/components/workspace/ModuleChatWindow.jsx
+++ b/src/components/workspace/ModuleChatWindow.jsx
@@ -706,7 +706,7 @@ export default function ModuleChatWindow({
             >
               <GifPicker
                 onGifClick={handleGifClick}
-                tenorApiKey={process.env.NEXT_PUBLIC_TENOR_API_KEY}
+                klipyApiKey={process.env.NEXT_PUBLIC_KLIPY_API_KEY}
                 theme="dark"
                 width={300}
                 height={380}

--- a/src/components/workspace/WorkspaceSettingsPanel.jsx
+++ b/src/components/workspace/WorkspaceSettingsPanel.jsx
@@ -38,6 +38,7 @@ export default function WorkspaceSettingsPanel({ workspaceId, onClose }) {
   const [editDesc, setEditDesc] = useState(workspace?.description || "");
   const [savingInfo, setSavingInfo] = useState(false);
   const [generatingInvite, setGeneratingInvite] = useState(false);
+  const [inviteExpiry, setInviteExpiry] = useState("never");
   const [copied, setCopied] = useState(false);
   const [showInviteModal, setShowInviteModal] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
@@ -71,7 +72,7 @@ export default function WorkspaceSettingsPanel({ workspaceId, onClose }) {
   const handleGenerateInvite = async () => {
     setGeneratingInvite(true);
     try {
-      await generateInvite(workspaceId);
+      await generateInvite(workspaceId, inviteExpiry);
       toast.success("Invite link generated");
     } catch (err) {
       toast.error("Failed to generate invite");
@@ -198,17 +199,51 @@ export default function WorkspaceSettingsPanel({ workspaceId, onClose }) {
                   </div>
                 </div>
               ) : (
-                <button
-                  onClick={handleGenerateInvite}
-                  disabled={generatingInvite}
-                  className="w-full h-9 rounded-xl bg-white/[0.04] hover:bg-white/[0.07] text-ivory/50 hover:text-ivory text-[12px] font-display font-bold border border-white/[0.06] transition-all disabled:opacity-40 flex items-center justify-center gap-1.5"
-                >
-                  <RefreshCw
-                    size={13}
-                    className={generatingInvite ? "animate-spin" : ""}
-                  />
-                  {generatingInvite ? "Generating..." : "Generate Invite Link"}
-                </button>
+                <div className="space-y-2">
+                  <select
+                    value={inviteExpiry}
+                    onChange={(e) => setInviteExpiry(e.target.value)}
+                    className="w-full bg-[#0f0f17] border border-white/[0.08] rounded-xl px-3 py-2 text-ivory/60 text-[12px] font-mono focus:outline-none focus:border-accent/40 transition-all appearance-none cursor-pointer"
+                  >
+                    <option value="30m" className="bg-[#0f0f17] text-ivory/80">
+                      Expires in 30 minutes
+                    </option>
+                    <option value="1h" className="bg-[#0f0f17] text-ivory/80">
+                      Expires in 1 hour
+                    </option>
+                    <option value="6h" className="bg-[#0f0f17] text-ivory/80">
+                      Expires in 6 hours
+                    </option>
+                    <option value="12h" className="bg-[#0f0f17] text-ivory/80">
+                      Expires in 12 hours
+                    </option>
+                    <option value="1d" className="bg-[#0f0f17] text-ivory/80">
+                      Expires in 1 day
+                    </option>
+                    <option value="7d" className="bg-[#0f0f17] text-ivory/80">
+                      Expires in 7 days
+                    </option>
+                    <option
+                      value="never"
+                      className="bg-[#0f0f17] text-ivory/80"
+                    >
+                      Never expires
+                    </option>
+                  </select>
+                  <button
+                    onClick={handleGenerateInvite}
+                    disabled={generatingInvite}
+                    className="w-full h-9 rounded-xl bg-white/[0.04] hover:bg-white/[0.07] text-ivory/50 hover:text-ivory text-[12px] font-display font-bold border border-white/[0.06] transition-all disabled:opacity-40 flex items-center justify-center gap-1.5"
+                  >
+                    <RefreshCw
+                      size={13}
+                      className={generatingInvite ? "animate-spin" : ""}
+                    />
+                    {generatingInvite
+                      ? "Generating..."
+                      : "Generate Invite Link"}
+                  </button>
+                </div>
               )}
             </section>
           )}
@@ -236,9 +271,18 @@ export default function WorkspaceSettingsPanel({ workspaceId, onClose }) {
             </p>
             {!isOwner && (
               <button
-                onClick={() => {
-                  // TODO: call leaveWorkspace(workspaceId) then router.push("/app/workspace")
-                  toast("Leave workspace — wire in Day 6");
+                onClick={async () => {
+                  try {
+                    await leaveWorkspace(workspaceId);
+                    toast.success("Left workspace");
+                    onClose();
+                    router.push("/app/workspace");
+                  } catch (err) {
+                    toast.error(
+                      err?.response?.data?.message ||
+                        "Failed to leave workspace",
+                    );
+                  }
                 }}
                 className="w-full h-9 rounded-xl bg-red-500/8 hover:bg-red-500/15 text-red-400/70 hover:text-red-400 text-[12px] font-display font-bold border border-red-500/15 transition-all flex items-center justify-center gap-1.5"
               >

--- a/src/context/ModuleContext.jsx
+++ b/src/context/ModuleContext.jsx
@@ -1,0 +1,3 @@
+import { createContext } from "react";
+
+export const ModuleContext = createContext(null);

--- a/src/context/ModuleProvider.jsx
+++ b/src/context/ModuleProvider.jsx
@@ -1,0 +1,321 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import { ModuleContext } from "./ModuleContext";
+import { useSocket } from "@/hooks/useSocket";
+import useAuth from "@/hooks/useAuth";
+
+// ── Days 1-3: mock service ────────────────────────────────────────────────
+// Day 4 swap: delete this import, uncomment the real service below
+import { getModuleMessages, sendModuleMessage } from "@/utils/mockModuleApi";
+
+// ── Day 4: real service (uncomment) ──────────────────────────────────────
+// import api from "@/app/api/Axios";
+// const getModuleMessages = ({ workspaceId, moduleId, page }) =>
+//   api.get(`/api/workspaces/${workspaceId}/modules/${moduleId}/messages?page=${page}`).then(r => r.data);
+// const sendModuleMessage = (payload) =>
+//   api.post(`/api/workspaces/${payload.workspaceId}/modules/${payload.moduleId}/messages`, payload).then(r => r.data);
+// ─────────────────────────────────────────────────────────────────────────
+
+export function ModuleProvider({ children, moduleId, workspaceId }) {
+  const { socket } = useSocket() || {};
+  const { user } = useAuth();
+
+  const [messages, setMessages] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [hasMore, setHasMore] = useState(false);
+  const [page, setPage] = useState(1);
+  const [reactions, setReactions] = useState({});
+  const [typingUsers, setTypingUsers] = useState([]); // [{ _id, name }]
+
+  const typingTimers = useRef({});
+  const seenInitRef = useRef(null);
+
+  // ── Fetch messages ───────────────────────────────────────────────────────
+  const fetchMessages = useCallback(
+    async (p = 1) => {
+      if (!moduleId || !workspaceId) return;
+      setLoading(true);
+      try {
+        const data = await getModuleMessages({
+          workspaceId,
+          moduleId,
+          page: p,
+        });
+        const msgs = data.messages || [];
+
+        // Build reactions map from loaded messages
+        const rxns = {};
+        msgs.forEach((msg) => {
+          if (msg.reactions && Object.keys(msg.reactions).length > 0) {
+            rxns[msg._id] = msg.reactions;
+          }
+        });
+
+        if (p === 1) {
+          setMessages(msgs);
+          setReactions(rxns);
+        } else {
+          // Prepend older messages (load more)
+          setMessages((prev) => [...msgs, ...prev]);
+          setReactions((prev) => ({ ...rxns, ...prev }));
+        }
+        setHasMore(data.hasMore || false);
+        setPage(p);
+      } catch (err) {
+        console.error("Failed to fetch module messages:", err);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [moduleId, workspaceId],
+  );
+
+  // Fetch on mount / when module changes
+  useEffect(() => {
+    setMessages([]);
+    setReactions({});
+    setTypingUsers([]);
+    setPage(1);
+    seenInitRef.current = null;
+    fetchMessages(1);
+  }, [moduleId, fetchMessages]);
+
+  // ── Socket: join/leave module room ───────────────────────────────────────
+  useEffect(() => {
+    if (!socket || !moduleId) return;
+    socket.emit("module:join", { moduleId, workspaceId });
+    return () => socket.emit("module:leave", { moduleId, workspaceId });
+  }, [socket, moduleId, workspaceId]);
+
+  // ── Socket: mark seen on initial load ───────────────────────────────────
+  useEffect(() => {
+    if (!socket || !user || !moduleId || loading) return;
+    if (seenInitRef.current === moduleId) return;
+
+    const lastMsg = [...messages]
+      .reverse()
+      .find(
+        (m) =>
+          m.sender?._id !== user._id &&
+          !m.readBy?.some?.((r) => r.user === user._id),
+      );
+    if (lastMsg) {
+      socket.emit("module:seen", {
+        moduleId,
+        workspaceId,
+        lastSeenMessageId: lastMsg._id,
+      });
+    }
+    seenInitRef.current = moduleId;
+  }, [socket, user, moduleId, workspaceId, loading, messages]);
+
+  // ── Socket: live event listeners ─────────────────────────────────────────
+  useEffect(() => {
+    if (!socket) return;
+
+    const onNewMessage = (msg) => {
+      if (msg.moduleId !== moduleId) return;
+
+      setMessages((prev) => {
+        // Replace optimistic placeholder if tempId matches
+        const optimisticIdx = prev.findIndex((m) => m._id === msg.tempId);
+        if (optimisticIdx !== -1) {
+          const updated = [...prev];
+          updated[optimisticIdx] = msg;
+          return updated;
+        }
+        // Deduplicate by _id
+        if (prev.find((m) => m._id === msg._id)) return prev;
+        return [...prev, msg];
+      });
+
+      // Auto-mark seen if we're viewing this module
+      if (msg.sender?._id !== user?._id && socket) {
+        socket.emit("module:seen", {
+          moduleId,
+          workspaceId,
+          lastSeenMessageId: msg._id,
+        });
+      }
+    };
+
+    const onReacted = ({ messageId, moduleId: mid, reactions: rxns }) => {
+      if (mid !== moduleId) return;
+      setReactions((prev) => ({ ...prev, [messageId]: rxns }));
+    };
+
+    const onEdited = (updatedMsg) => {
+      if (updatedMsg.moduleId !== moduleId) return;
+      setMessages((prev) =>
+        prev.map((m) =>
+          m._id === updatedMsg._id ? { ...m, ...updatedMsg } : m,
+        ),
+      );
+    };
+
+    const onDeleted = ({ messageId, moduleId: mid, forEveryone }) => {
+      if (mid !== moduleId) return;
+      if (forEveryone) {
+        setMessages((prev) =>
+          prev.map((m) =>
+            m._id === messageId ? { ...m, isDeleted: true } : m,
+          ),
+        );
+      } else {
+        // "Delete for me" — remove from local list only
+        setMessages((prev) => prev.filter((m) => m._id !== messageId));
+      }
+    };
+
+    const onTypingStart = ({ userId, userName, moduleId: mid }) => {
+      if (mid !== moduleId || userId === user?._id) return;
+      setTypingUsers((prev) => {
+        if (prev.find((u) => u._id === userId)) return prev;
+        return [...prev, { _id: userId, name: userName }];
+      });
+      // Auto-clear after 4 seconds in case stop event is missed
+      clearTimeout(typingTimers.current[userId]);
+      typingTimers.current[userId] = setTimeout(() => {
+        setTypingUsers((prev) => prev.filter((u) => u._id !== userId));
+      }, 4000);
+    };
+
+    const onTypingStop = ({ userId, moduleId: mid }) => {
+      if (mid !== moduleId) return;
+      clearTimeout(typingTimers.current[userId]);
+      delete typingTimers.current[userId];
+      setTypingUsers((prev) => prev.filter((u) => u._id !== userId));
+    };
+
+    socket.on("module:message:new", onNewMessage);
+    socket.on("module:message:reacted", onReacted);
+    socket.on("module:message:edited", onEdited);
+    socket.on("module:message:deleted", onDeleted);
+    socket.on("module:typing:start", onTypingStart);
+    socket.on("module:typing:stop", onTypingStop);
+
+    return () => {
+      socket.off("module:message:new", onNewMessage);
+      socket.off("module:message:reacted", onReacted);
+      socket.off("module:message:edited", onEdited);
+      socket.off("module:message:deleted", onDeleted);
+      socket.off("module:typing:start", onTypingStart);
+      socket.off("module:typing:stop", onTypingStop);
+
+      // Clean up all typing timers for this module
+      Object.values(typingTimers.current).forEach(clearTimeout);
+      typingTimers.current = {};
+    };
+  }, [socket, moduleId, workspaceId, user?._id]);
+
+  // ── Actions exposed to consumers ─────────────────────────────────────────
+  const sendMessage = useCallback(
+    ({ text, gifUrl, replyTo }) => {
+      if (!socket || !moduleId) return;
+
+      const tempId = `temp-${Date.now()}`;
+      const optimistic = {
+        _id: tempId,
+        moduleId,
+        workspaceId,
+        sender: { _id: user?._id, name: user?.name, avatar: user?.avatar },
+        text: text || null,
+        gifUrl: gifUrl || null,
+        replyTo: replyTo || null,
+        createdAt: new Date().toISOString(),
+        reactions: {},
+        isDeleted: false,
+        isEdited: false,
+        isOptimistic: true,
+        tempId,
+      };
+      setMessages((prev) => [...prev, optimistic]);
+
+      socket.emit("module:message:send", {
+        moduleId,
+        workspaceId,
+        text,
+        gifUrl,
+        replyTo: replyTo?._id || null,
+        tempId,
+      });
+
+      // Stop typing indicator
+      socket.emit("module:typing:stop", { moduleId, workspaceId });
+    },
+    [socket, moduleId, workspaceId, user],
+  );
+
+  const sendTyping = useCallback(
+    (isTyping) => {
+      if (!socket || !moduleId) return;
+      socket.emit(isTyping ? "module:typing:start" : "module:typing:stop", {
+        moduleId,
+        workspaceId,
+      });
+    },
+    [socket, moduleId, workspaceId],
+  );
+
+  const reactToMessage = useCallback(
+    (messageId, emoji) => {
+      if (!socket) return;
+      socket.emit("module:message:react", {
+        moduleId,
+        workspaceId,
+        messageId,
+        emoji,
+      });
+    },
+    [socket, moduleId, workspaceId],
+  );
+
+  const editMessage = useCallback(
+    (messageId, newText) => {
+      if (!socket) return;
+      socket.emit("module:message:edit", {
+        moduleId,
+        workspaceId,
+        messageId,
+        newText,
+      });
+    },
+    [socket, moduleId, workspaceId],
+  );
+
+  const deleteMessage = useCallback(
+    (messageId, forEveryone = false) => {
+      if (!socket) return;
+      socket.emit("module:message:delete", {
+        moduleId,
+        workspaceId,
+        messageId,
+        forEveryone,
+      });
+    },
+    [socket, moduleId, workspaceId],
+  );
+
+  const loadMore = useCallback(() => {
+    if (hasMore && !loading) fetchMessages(page + 1);
+  }, [hasMore, loading, fetchMessages, page]);
+
+  const value = {
+    messages,
+    loading,
+    hasMore,
+    loadMore,
+    reactions,
+    typingUsers,
+    sendMessage,
+    sendTyping,
+    reactToMessage,
+    editMessage,
+    deleteMessage,
+  };
+
+  return (
+    <ModuleContext.Provider value={value}>{children}</ModuleContext.Provider>
+  );
+}

--- a/src/context/ModuleProvider.jsx
+++ b/src/context/ModuleProvider.jsx
@@ -5,17 +5,20 @@ import { ModuleContext } from "./ModuleContext";
 import { useSocket } from "@/hooks/useSocket";
 import useAuth from "@/hooks/useAuth";
 
-// ── Days 1-3: mock service ────────────────────────────────────────────────
-// Day 4 swap: delete this import, uncomment the real service below
-import { getModuleMessages, sendModuleMessage } from "@/utils/mockModuleApi";
-
-// ── Day 4: real service (uncomment) ──────────────────────────────────────
-// import api from "@/app/api/Axios";
-// const getModuleMessages = ({ workspaceId, moduleId, page }) =>
-//   api.get(`/api/workspaces/${workspaceId}/modules/${moduleId}/messages?page=${page}`).then(r => r.data);
-// const sendModuleMessage = (payload) =>
-//   api.post(`/api/workspaces/${payload.workspaceId}/modules/${payload.moduleId}/messages`, payload).then(r => r.data);
-// ─────────────────────────────────────────────────────────────────────────
+import api from "@/app/api/Axios";
+const getModuleMessages = ({ workspaceId, moduleId, page }) =>
+  api
+    .get(
+      `/api/workspaces/${workspaceId}/modules/${moduleId}/messages?page=${page}`,
+    )
+    .then((r) => r.data);
+const sendModuleMessage = (payload) =>
+  api
+    .post(
+      `/api/workspaces/${payload.workspaceId}/modules/${payload.moduleId}/messages`,
+      payload,
+    )
+    .then((r) => r.data);
 
 export function ModuleProvider({ children, moduleId, workspaceId }) {
   const { socket } = useSocket() || {};

--- a/src/context/ModuleProvider.jsx
+++ b/src/context/ModuleProvider.jsx
@@ -84,11 +84,23 @@ export function ModuleProvider({ children, moduleId, workspaceId }) {
     fetchMessages(1);
   }, [moduleId, fetchMessages]);
 
-  // ── Socket: join/leave module room ───────────────────────────────────────
+  // ── Socket: join/leave module room (also handles reconnects) ──────────────
   useEffect(() => {
     if (!socket || !moduleId) return;
-    socket.emit("module:join", { moduleId, workspaceId });
-    return () => socket.emit("module:leave", { moduleId, workspaceId });
+
+    const joinRoom = () => {
+      socket.emit("module:join", { moduleId, workspaceId });
+    };
+
+    joinRoom();
+    // Re-join after socket reconnects (socket instance is reused, so the
+    // effect won't re-run on reconnect — we must listen for "connect" directly)
+    socket.on("connect", joinRoom);
+
+    return () => {
+      socket.off("connect", joinRoom);
+      socket.emit("module:leave", { moduleId, workspaceId });
+    };
   }, [socket, moduleId, workspaceId]);
 
   // ── Socket: mark seen on initial load ───────────────────────────────────

--- a/src/context/WorkspaceProvider.jsx
+++ b/src/context/WorkspaceProvider.jsx
@@ -170,6 +170,20 @@ export function WorkspaceProvider({ children }) {
     }));
   }, []);
 
+  const addCategory = useCallback(async (workspaceId, name) => {
+    const category = await api
+      .post(`/api/workspaces/${workspaceId}/categories`, { name })
+      .then((r) => r.data);
+    setWorkspaces((prev) =>
+      prev.map((w) =>
+        w._id === workspaceId
+          ? { ...w, categories: [...(w.categories || []), category] }
+          : w,
+      ),
+    );
+    return category;
+  }, []);
+
   // ── Socket: workspace + module live events ───────────────────────────────
   useEffect(() => {
     if (!socket) return;
@@ -215,11 +229,22 @@ export function WorkspaceProvider({ children }) {
       }));
     };
 
+    const onCategoryAdded = ({ workspaceId, category }) => {
+      setWorkspaces((prev) =>
+        prev.map((w) =>
+          w._id === workspaceId
+            ? { ...w, categories: [...(w.categories || []), category] }
+            : w,
+        ),
+      );
+    };
+
     socket.on("workspace:updated", onWorkspaceUpdated);
     socket.on("workspace:deleted", onWorkspaceDeleted);
     socket.on("module:created", onModuleCreated);
     socket.on("module:updated", onModuleUpdated);
     socket.on("module:deleted", onModuleDeleted);
+    socket.on("workspace:category-added", onCategoryAdded);
 
     return () => {
       socket.off("workspace:updated", onWorkspaceUpdated);
@@ -227,6 +252,7 @@ export function WorkspaceProvider({ children }) {
       socket.off("module:created", onModuleCreated);
       socket.off("module:updated", onModuleUpdated);
       socket.off("module:deleted", onModuleDeleted);
+      socket.off("workspace:category-added", onCategoryAdded);
     };
   }, [socket]);
 
@@ -246,6 +272,7 @@ export function WorkspaceProvider({ children }) {
     createModule,
     updateModule,
     deleteModule,
+    addCategory,
   };
 
   return (

--- a/src/context/WorkspaceProvider.jsx
+++ b/src/context/WorkspaceProvider.jsx
@@ -174,14 +174,19 @@ export function WorkspaceProvider({ children }) {
     const category = await api
       .post(`/api/workspaces/${workspaceId}/categories`, { name })
       .then((r) => r.data);
-    setWorkspaces((prev) =>
-      prev.map((w) =>
-        w._id === workspaceId
-          ? { ...w, categories: [...(w.categories || []), category] }
-          : w,
-      ),
-    );
     return category;
+  }, []);
+
+  const updateCategory = useCallback(async (workspaceId, categoryId, name) => {
+    await api.patch(`/api/workspaces/${workspaceId}/categories/${categoryId}`, {
+      name,
+    });
+    // socket event workspace:category-updated handles state update
+  }, []);
+
+  const deleteCategory = useCallback(async (workspaceId, categoryId) => {
+    await api.delete(`/api/workspaces/${workspaceId}/categories/${categoryId}`);
+    // socket event workspace:category-deleted handles state update
   }, []);
 
   // ── Socket: workspace + module live events ───────────────────────────────
@@ -231,11 +236,42 @@ export function WorkspaceProvider({ children }) {
 
     const onCategoryAdded = ({ workspaceId, category }) => {
       setWorkspaces((prev) =>
-        prev.map((w) =>
-          w._id === workspaceId
-            ? { ...w, categories: [...(w.categories || []), category] }
-            : w,
-        ),
+        prev.map((w) => {
+          if (w._id !== workspaceId) return w;
+          const already = (w.categories || []).some(
+            (c) => c._id?.toString() === category._id?.toString(),
+          );
+          if (already) return w;
+          return { ...w, categories: [...(w.categories || []), category] };
+        }),
+      );
+    };
+
+    const onCategoryUpdated = ({ workspaceId, category }) => {
+      setWorkspaces((prev) =>
+        prev.map((w) => {
+          if (w._id !== workspaceId) return w;
+          return {
+            ...w,
+            categories: (w.categories || []).map((c) =>
+              c._id?.toString() === category._id?.toString() ? category : c,
+            ),
+          };
+        }),
+      );
+    };
+
+    const onCategoryDeleted = ({ workspaceId, categoryId }) => {
+      setWorkspaces((prev) =>
+        prev.map((w) => {
+          if (w._id !== workspaceId) return w;
+          return {
+            ...w,
+            categories: (w.categories || []).filter(
+              (c) => c._id?.toString() !== categoryId?.toString(),
+            ),
+          };
+        }),
       );
     };
 
@@ -245,6 +281,8 @@ export function WorkspaceProvider({ children }) {
     socket.on("module:updated", onModuleUpdated);
     socket.on("module:deleted", onModuleDeleted);
     socket.on("workspace:category-added", onCategoryAdded);
+    socket.on("workspace:category-updated", onCategoryUpdated);
+    socket.on("workspace:category-deleted", onCategoryDeleted);
 
     return () => {
       socket.off("workspace:updated", onWorkspaceUpdated);
@@ -253,6 +291,8 @@ export function WorkspaceProvider({ children }) {
       socket.off("module:updated", onModuleUpdated);
       socket.off("module:deleted", onModuleDeleted);
       socket.off("workspace:category-added", onCategoryAdded);
+      socket.off("workspace:category-updated", onCategoryUpdated);
+      socket.off("workspace:category-deleted", onCategoryDeleted);
     };
   }, [socket]);
 
@@ -273,6 +313,8 @@ export function WorkspaceProvider({ children }) {
     updateModule,
     deleteModule,
     addCategory,
+    updateCategory,
+    deleteCategory,
   };
 
   return (

--- a/src/context/WorkspaceProvider.jsx
+++ b/src/context/WorkspaceProvider.jsx
@@ -5,38 +5,28 @@ import { WorkspaceContext } from "./WorkspaceContext";
 import { useSocket } from "@/hooks/useSocket";
 import toast from "react-hot-toast";
 
-// ── Days 1-5: mock service  ────────────────────────────────────────────────
-// Day 6 swap: delete this import block, uncomment the real service imports below
-import {
-  listMyWorkspaces,
-  getWorkspace,
-  createWorkspace as apiCreateWorkspace,
-  updateWorkspace as apiUpdateWorkspace,
-  deleteWorkspace as apiDeleteWorkspace,
-  generateInvite as apiGenerateInvite,
-  revokeInvite as apiRevokeInvite,
-  joinViaInvite as apiJoinViaInvite,
-  listModules,
-  createModule as apiCreateModule,
-  updateModule as apiUpdateModule,
-  deleteModule as apiDeleteModule,
-} from "@/utils/mockWorkspaceApi";
-
-// ── Day 6: real service (uncomment when backend is ready) ─────────────────
-// import api from "@/app/api/Axios";
-// const listMyWorkspaces   = () => api.get("/api/workspaces").then(r => r.data);
-// const getWorkspace       = (id) => api.get(`/api/workspaces/${id}`).then(r => r.data);
-// const apiCreateWorkspace = (d) => api.post("/api/workspaces", d).then(r => r.data);
-// const apiUpdateWorkspace = (id, d) => api.patch(`/api/workspaces/${id}`, d).then(r => r.data);
-// const apiDeleteWorkspace = (id) => api.delete(`/api/workspaces/${id}`);
-// const apiGenerateInvite  = (id) => api.post(`/api/workspaces/${id}/invite`).then(r => r.data);
-// const apiRevokeInvite    = (id) => api.delete(`/api/workspaces/${id}/invite`);
-// const apiJoinViaInvite   = (code) => api.post(`/api/workspaces/join/${code}`).then(r => r.data);
-// const listModules        = (wsId) => api.get(`/api/workspaces/${wsId}/modules`).then(r => r.data);
-// const apiCreateModule    = (wsId, d) => api.post(`/api/workspaces/${wsId}/modules`, d).then(r => r.data);
-// const apiUpdateModule    = (wsId, mid, d) => api.patch(`/api/workspaces/${wsId}/modules/${mid}`, d).then(r => r.data);
-// const apiDeleteModule    = (wsId, mid) => api.delete(`/api/workspaces/${wsId}/modules/${mid}`);
-// ─────────────────────────────────────────────────────────────────────────
+import api from "@/app/api/Axios";
+const listMyWorkspaces = () => api.get("/api/workspaces").then((r) => r.data);
+const getWorkspace = (id) =>
+  api.get(`/api/workspaces/${id}`).then((r) => r.data);
+const apiCreateWorkspace = (d) =>
+  api.post("/api/workspaces", d).then((r) => r.data);
+const apiUpdateWorkspace = (id, d) =>
+  api.patch(`/api/workspaces/${id}`, d).then((r) => r.data);
+const apiDeleteWorkspace = (id) => api.delete(`/api/workspaces/${id}`);
+const apiGenerateInvite = (id) =>
+  api.post(`/api/workspaces/${id}/invite`).then((r) => r.data);
+const apiRevokeInvite = (id) => api.delete(`/api/workspaces/${id}/invite`);
+const apiJoinViaInvite = (code) =>
+  api.post(`/api/workspaces/join/${code}`).then((r) => r.data);
+const listModules = (wsId) =>
+  api.get(`/api/workspaces/${wsId}/modules`).then((r) => r.data);
+const apiCreateModule = (wsId, d) =>
+  api.post(`/api/workspaces/${wsId}/modules`, d).then((r) => r.data);
+const apiUpdateModule = (wsId, mid, d) =>
+  api.patch(`/api/workspaces/${wsId}/modules/${mid}`, d).then((r) => r.data);
+const apiDeleteModule = (wsId, mid) =>
+  api.delete(`/api/workspaces/${wsId}/modules/${mid}`);
 
 export function WorkspaceProvider({ children }) {
   const { socket } = useSocket() || {};
@@ -122,9 +112,7 @@ export function WorkspaceProvider({ children }) {
   const revokeInvite = useCallback(async (workspaceId) => {
     await apiRevokeInvite(workspaceId);
     setWorkspaces((prev) =>
-      prev.map((w) =>
-        w._id === workspaceId ? { ...w, inviteCode: null } : w,
-      ),
+      prev.map((w) => (w._id === workspaceId ? { ...w, inviteCode: null } : w)),
     );
   }, []);
 
@@ -213,18 +201,18 @@ export function WorkspaceProvider({ children }) {
       }));
     };
 
-    socket.on("workspace:updated",   onWorkspaceUpdated);
-    socket.on("workspace:deleted",   onWorkspaceDeleted);
-    socket.on("module:created",      onModuleCreated);
-    socket.on("module:updated",      onModuleUpdated);
-    socket.on("module:deleted",      onModuleDeleted);
+    socket.on("workspace:updated", onWorkspaceUpdated);
+    socket.on("workspace:deleted", onWorkspaceDeleted);
+    socket.on("module:created", onModuleCreated);
+    socket.on("module:updated", onModuleUpdated);
+    socket.on("module:deleted", onModuleDeleted);
 
     return () => {
-      socket.off("workspace:updated",   onWorkspaceUpdated);
-      socket.off("workspace:deleted",   onWorkspaceDeleted);
-      socket.off("module:created",      onModuleCreated);
-      socket.off("module:updated",      onModuleUpdated);
-      socket.off("module:deleted",      onModuleDeleted);
+      socket.off("workspace:updated", onWorkspaceUpdated);
+      socket.off("workspace:deleted", onWorkspaceDeleted);
+      socket.off("module:created", onModuleCreated);
+      socket.off("module:updated", onModuleUpdated);
+      socket.off("module:deleted", onModuleDeleted);
     };
   }, [socket]);
 
@@ -251,4 +239,3 @@ export function WorkspaceProvider({ children }) {
     </WorkspaceContext.Provider>
   );
 }
-

--- a/src/context/WorkspaceProvider.jsx
+++ b/src/context/WorkspaceProvider.jsx
@@ -14,8 +14,8 @@ const apiCreateWorkspace = (d) =>
 const apiUpdateWorkspace = (id, d) =>
   api.patch(`/api/workspaces/${id}`, d).then((r) => r.data);
 const apiDeleteWorkspace = (id) => api.delete(`/api/workspaces/${id}`);
-const apiGenerateInvite = (id) =>
-  api.post(`/api/workspaces/${id}/invite`).then((r) => r.data);
+const apiGenerateInvite = (id, expiresIn = "never") =>
+  api.post(`/api/workspaces/${id}/invite`, { expiresIn }).then((r) => r.data);
 const apiRevokeInvite = (id) => api.delete(`/api/workspaces/${id}/invite`);
 const apiJoinViaInvite = (code) =>
   api.post(`/api/workspaces/join/${code}`).then((r) => r.data);
@@ -101,13 +101,16 @@ export function WorkspaceProvider({ children }) {
   }, []);
 
   // ── Invite management ────────────────────────────────────────────────────
-  const generateInvite = useCallback(async (workspaceId) => {
-    const { inviteCode } = await apiGenerateInvite(workspaceId);
-    setWorkspaces((prev) =>
-      prev.map((w) => (w._id === workspaceId ? { ...w, inviteCode } : w)),
-    );
-    return inviteCode;
-  }, []);
+  const generateInvite = useCallback(
+    async (workspaceId, expiresIn = "never") => {
+      const { inviteCode } = await apiGenerateInvite(workspaceId, expiresIn);
+      setWorkspaces((prev) =>
+        prev.map((w) => (w._id === workspaceId ? { ...w, inviteCode } : w)),
+      );
+      return inviteCode;
+    },
+    [],
+  );
 
   const revokeInvite = useCallback(async (workspaceId) => {
     await apiRevokeInvite(workspaceId);
@@ -123,6 +126,17 @@ export function WorkspaceProvider({ children }) {
       return [ws, ...prev];
     });
     return ws;
+  }, []);
+
+  const leaveWorkspace = useCallback(async (workspaceId) => {
+    await api.post(`/api/workspaces/${workspaceId}/leave`);
+    setWorkspaces((prev) => prev.filter((w) => w._id !== workspaceId));
+    setModulesCache((prev) => {
+      const next = { ...prev };
+      delete next[workspaceId];
+      return next;
+    });
+    fetchedWorkspaceIds.current.delete(workspaceId);
   }, []);
 
   // ── Module CRUD ──────────────────────────────────────────────────────────
@@ -228,6 +242,7 @@ export function WorkspaceProvider({ children }) {
     generateInvite,
     revokeInvite,
     joinViaInvite,
+    leaveWorkspace,
     createModule,
     updateModule,
     deleteModule,

--- a/src/hooks/useModule.js
+++ b/src/hooks/useModule.js
@@ -1,0 +1,8 @@
+import { useContext } from "react";
+import { ModuleContext } from "@/context/ModuleContext";
+
+export function useModule() {
+  const ctx = useContext(ModuleContext);
+  if (!ctx) throw new Error("useModule must be used inside ModuleProvider");
+  return ctx;
+}

--- a/src/utils/mockModuleApi.js
+++ b/src/utils/mockModuleApi.js
@@ -1,0 +1,82 @@
+// src/utils/mockModuleApi.js
+// ── Mock backend for ModuleMessage features (Days 1-3) ──────────────────
+// Day 4 swap: delete this file and change the import in ModuleProvider.jsx
+// to the real moduleService.js (same function names, same return shapes)
+
+const delay = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// Per-module message store (in-memory, survives hot reload in dev)
+const MODULE_MESSAGES = {};
+
+const seedMessages = (moduleId) => {
+  if (MODULE_MESSAGES[moduleId]) return;
+  const now = Date.now();
+  MODULE_MESSAGES[moduleId] = [
+    {
+      _id: `msg-seed-1-${moduleId}`,
+      moduleId,
+      sender: { _id: "u2", name: "Alex R.", avatar: null },
+      text: "Hey everyone, welcome to this module! 👋",
+      createdAt: new Date(now - 1000 * 60 * 60 * 2).toISOString(),
+      reactions: {},
+      isDeleted: false,
+      isEdited: false,
+    },
+    {
+      _id: `msg-seed-2-${moduleId}`,
+      moduleId,
+      sender: { _id: "u3", name: "Jamie L.", avatar: null },
+      text: "Great to be here. Let's build something awesome.",
+      createdAt: new Date(now - 1000 * 60 * 30).toISOString(),
+      reactions: { "👍": ["u2"] },
+      isDeleted: false,
+      isEdited: false,
+    },
+  ];
+};
+
+export const getModuleMessages = async ({
+  workspaceId,
+  moduleId,
+  page = 1,
+}) => {
+  await delay(200);
+  seedMessages(moduleId);
+  const all = MODULE_MESSAGES[moduleId] || [];
+  const pageSize = 30;
+  const start = Math.max(0, all.length - page * pageSize);
+  const end = all.length - (page - 1) * pageSize;
+  return {
+    messages: all.slice(start, end),
+    hasMore: start > 0,
+    page,
+  };
+};
+
+export const sendModuleMessage = async ({
+  workspaceId,
+  moduleId,
+  text,
+  gifUrl,
+  replyTo,
+  tempId,
+}) => {
+  await delay(80);
+  seedMessages(moduleId);
+  const msg = {
+    _id: `msg-${Date.now()}`,
+    moduleId,
+    workspaceId,
+    sender: { _id: "me", name: "You", avatar: null },
+    text: text || null,
+    gifUrl: gifUrl || null,
+    replyTo: replyTo || null,
+    createdAt: new Date().toISOString(),
+    reactions: {},
+    isDeleted: false,
+    isEdited: false,
+    tempId,
+  };
+  MODULE_MESSAGES[moduleId].push(msg);
+  return msg;
+};


### PR DESCRIPTION
## Workspace Module Chat — Sprint Day 3 (Rezaul) - 11 Mar

### Overview

Built the full `ModuleChatWindow` component and `CreateModuleModal`, wiring the complete UI for module-based chat within workspaces. This covers the message list, send bar, reactions, edit/delete, reply, typing indicators, GIF picker, and emoji picker — all driven by `useModule()` from the provider built on Day 2.

---

### 1. ModuleChatWindow

**`src/components/workspace/ModuleChatWindow.jsx`** _(new file)_

Full-featured chat window scoped to a single module. Reads all state from `useModule()` (messages, loading, hasMore, reactions, typingUsers) and dispatches actions (sendMessage, sendTyping, reactToMessage, editMessage, deleteMessage, loadMore).

**Key features:**

- Infinite scroll — `IntersectionObserver` on a sentinel `<div>` at the top triggers `loadMore()` when `hasMore` is true
- Optimistic UI — messages appended immediately on send; replaced by the confirmed socket echo via `tempId`
- Date separators — groups messages by calendar day ("Today", "Yesterday", or formatted date)
- Typing indicator — shows `"X is typing…"` / `"X and Y are typing…"` in the footer
- Reply-thread preview — clicking the reply icon sets `replyTo` state; shows quoted snippet above the input; `×` clears it
- Emoji quick-reactions — 7-emoji row in a hover toolbar; full `EmojiPicker` (dynamically imported) for the "+" button
- GIF support — `GifPicker` (dynamically imported from `gif-picker-react-klipy`) opens in a popover; selected GIF sent as `gifUrl`
- Edit / delete actions — pencil opens an inline edit input; trash opens a "delete for me / for everyone" confirmation flow
- Mobile hamburger menu (☰) — emits `onToggleSidebar()` prop to let the parent toggle the mobile channel sidebar overlay

---

### 2. CreateModuleModal

**`src/components/workspace/CreateModuleModal.jsx`** _(new file)_

Portal-rendered modal for creating a new module (channel) inside a workspace.

- Reads existing categories from `WorkspaceContext` and pre-selects `defaultCategory` prop
- Module type picker: **Text** (Hash icon) or **Announcement** (Megaphone icon)
- Private toggle with Lock icon
- Auto-generates a slug from the name on submit
- Calls `createModule({ workspaceId, name, type, category, isPrivate })` from `useWorkspace()`
- On success: navigates to the new module's route, then calls `onClose()`

---

### Files Created

| File                                             | Action     |
| ------------------------------------------------ | ---------- |
| `src/components/workspace/ModuleChatWindow.jsx`  | **CREATE** |
| `src/components/workspace/CreateModuleModal.jsx` | **CREATE** |

---

## Workspace Module Chat — Sprint Day 4 (Rezaul) - 11 Mar

### Overview

Wired the two workspace route pages to use the new components, and swapped `ModuleProvider` from the mock API to the real Axios-backed API.

---

### 1. `[id]/page.jsx` — Workspace landing (no module selected)

**`src/app/app/workspace/[id]/page.jsx`** _(modified)_

- Added import: `CreateModuleModal`
- Added state: `showCreateModule` (bool), `createModuleCategory` (string, default `"General"`)
- Wired `onCreateModule` on `ChannelSidebar`: sets category from the clicked group name (or falls back to `"General"`) and opens the modal
- Mounted `<CreateModuleModal>` conditionally below the layout tree (outside the flex container so the portal renders correctly)
- Center placeholder ("Select a module…") left unchanged — correct behaviour when no module is active

---

### 2. `[id]/[moduleId]/page.jsx` — Active module chat view

**`src/app/app/workspace/[id]/[moduleId]/page.jsx`** _(modified)_

- Added imports: `ModuleProvider`, `ModuleChatWindow`, `CreateModuleModal`
- Added state: `isSidebarOpen` (bool), `showCreateModule` (bool), `createModuleCategory` (string)
- Replaced placeholder center div with:
  ```jsx
  <ModuleProvider moduleId={moduleId} workspaceId={id}>
    <ModuleChatWindow
      moduleId={moduleId}
      workspaceId={id}
      onToggleSidebar={() => setIsSidebarOpen((v) => !v)}
    />
  </ModuleProvider>
  ```
- Added mobile sidebar overlay: when `isSidebarOpen`, an absolute `z-40` panel renders on `md:hidden` screens with a backdrop click-to-close; contains a full `ChannelSidebar` instance with `onCreateModule` and `onSettingsOpen` wired
- Desktop `ChannelSidebar` (`hidden md:flex`) also wired with `onCreateModule`
- Mounted `<CreateModuleModal>` conditionally

---

### 3. ModuleProvider.jsx — Real API swap

**`src/context/ModuleProvider.jsx`** _(modified)_

- Deleted mock import block (`import { getModuleMessages, sendModuleMessage } from "@/utils/mockModuleApi"` + comment lines)
- Uncommented real service — `api.get` for fetching messages, `api.post` for sending — wired to `/api/workspaces/:workspaceId/modules/:moduleId/messages`

---

### Files Modified

| File                                             | Action   |
| ------------------------------------------------ | -------- |
| `src/app/app/workspace/[id]/page.jsx`            | **EDIT** |
| `src/app/app/workspace/[id]/[moduleId]/page.jsx` | **EDIT** |
| `src/context/ModuleProvider.jsx`                 | **EDIT** |

---



**Title:** `feat: category management UI + module chat bug fixes (real-time, GIF picker, reconnect)`

**Description:**

### Summary
Fixes the GIF picker, real-time message delivery, and page-reload message loss in workspace module chat. Adds full category management to the channel sidebar (create, rename, delete) with a hamburger dropdown menu and empty-category visibility.

---

### Bug Fixes

#### 🐛 GIF picker "Invalid API key" error
`gif-picker-react-klipy` expects `klipyApiKey` but the component was passing `tenorApiKey`.

**Fix:** `src/components/workspace/ModuleChatWindow.jsx` — renamed prop.

#### 🐛 GIF / emoji picker hidden behind message bubbles
Message bubbles had a stacking context that covered the picker popovers.

**Fix:** `src/components/ChatDashboard/ChatWindow.jsx` — added `z-20` to the input form wrapper (`z-10` on bubbles).

#### 🐛 Module messages gone after reload
Companion to the server fix — `ModuleProvider` now correctly receives `{ messages, hasMore }` from the API and renders persisted history on load.

#### 🐛 Real-time delivery broken after server restart / reconnect
Socket.IO reuses the same socket object on reconnection, so the `module:join` `useEffect` (which depends on `[socket, moduleId, workspaceId]`) never re-fires — leaving the client outside the socket room with no live events.

**Fix:** `src/context/ModuleProvider.jsx` — added a `"connect"` listener directly on the socket so `module:join` is re-emitted on every reconnection:
```js
const joinRoom = () => socket.emit("module:join", { moduleId, workspaceId });
joinRoom();
socket.on("connect", joinRoom);
return () => {
  socket.off("connect", joinRoom);
  socket.emit("module:leave", { moduleId, workspaceId });
};
```

---

### Features

#### ✨ Create Category
`FolderPlus` icon button in the `ChannelSidebar` header opens an inline input form. On submit, calls `addCategory` from `WorkspaceContext` (POST only — socket event is the single source of truth for state update, preventing duplicate entries).

#### ✨ Category hamburger menu (Rename / Delete)
`MoreHorizontal` (`···`) icon appears on hover for each category group. Opens a dropdown with three actions:

| Action | Behaviour |
| --- | --- |
| Add module | Opens `CreateModuleModal` pre-filled with this category |
| Rename category | Inline `<input>` replaces the label; Enter / blur submits `updateCategory` |
| Delete category | Calls `deleteCategory` and closes the menu |

Click-outside listener via `useEffect` on `document` closes the dropdown automatically.

#### ✨ Empty categories visible in sidebar
`groupedModules` now iterates `workspace.categories` as the source of truth rather than deriving groups only from loaded modules. Categories with no modules are included with `modules: []`.

#### ✨ WorkspaceProvider — full category CRUD + socket sync
Three new actions exposed on context:

| Action | Endpoint |
| --- | --- |
| `addCategory(workspaceId, name)` | `POST /api/workspaces/:id/categories` |
| `updateCategory(workspaceId, categoryId, name)` | `PATCH /api/workspaces/:id/categories/:catId` |
| `deleteCategory(workspaceId, categoryId)` | `DELETE /api/workspaces/:id/categories/:catId` |

Three new socket listeners with deduplication guards:

| Event | State update |
| --- | --- |
| `workspace:category-added` | Appends (skips if `_id` already present) |
| `workspace:category-updated` | Merges updated name |
| `workspace:category-deleted` | Removes by `categoryId` |

---

### Files Changed
| File | Change |
| --- | --- |
| `src/components/workspace/ModuleChatWindow.jsx` | `klipyApiKey` prop fix |
| `src/components/ChatDashboard/ChatWindow.jsx` | `z-20` form wrapper |
| `src/components/ChatDashboard/ChannelSidebar.jsx` | Create category input, hamburger menu, empty-category visibility, `groupedModules` dedup |
| `src/context/WorkspaceProvider.jsx` | `addCategory`, `updateCategory`, `deleteCategory`, socket listeners |
| `src/context/ModuleProvider.jsx` | Reconnect-safe `module:join` via `"connect"` listener |

---

### Testing
- Open a workspace module → reload → messages should still be there
- Open the same module in two tabs → send a message → should appear in both instantly
- Restart the dev server while on a module page → send a message → should still deliver in real time
- Click `+` folder icon → create a new category → should appear without duplicate
- Hover a category → click `···` → rename and delete should work
- Create a category with no modules → it should show in the sidebar