### PR TITLE
feat: added ai suggestion and ai rewrite feature

### DIFF
--- a/src/app/api/ai-reply/route.js
+++ b/src/app/api/ai-reply/route.js
@@ -1,0 +1,117 @@
+import { NextResponse } from "next/server";
+
+const OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY;
+const MODEL = "nvidia/nemotron-3-super-120b-a12b:free";
+
+function extractSuggestions(text) {
+  if (!text) return [];
+
+  // Try JSON array first
+  try {
+    const jsonMatch = text.match(/\[[\s\S]*?\]/);
+    if (jsonMatch) {
+      const parsed = JSON.parse(jsonMatch[0]);
+      if (Array.isArray(parsed)) {
+        const result = parsed.filter((s) => typeof s === "string" && s.length > 1);
+        if (result.length > 0) return result.slice(0, 3);
+      }
+    }
+  } catch {}
+
+  // Fallback: extract quoted strings
+  const quoted = [...text.matchAll(/"([^"]{3,80})"/g)].map((m) => m[1]);
+  if (quoted.length >= 2) return quoted.slice(0, 3);
+
+  // Fallback: numbered/bulleted list like "1. Sure thing!" or "- Sure thing!"
+  const listed = [...text.matchAll(/^[\s]*[1-3\-*•]\.*\s+(.{5,80})$/gm)].map((m) =>
+    m[1].replace(/^["']|["']$/g, "").trim(),
+  );
+  if (listed.length >= 2) return listed.slice(0, 3);
+
+  return [];
+}
+
+export async function POST(req) {
+  if (!OPENROUTER_API_KEY) {
+    return NextResponse.json(
+      { error: "OpenRouter API key not configured" },
+      { status: 500 },
+    );
+  }
+
+  try {
+    const { messages, latestMessage } = await req.json();
+
+    if (!latestMessage?.trim()) {
+      return NextResponse.json({ suggestions: [] });
+    }
+
+    const systemPrompt = `You are a chat reply assistant. Suggest exactly 3 short, natural reply options (each under 12 words) for the latest message. Output ONLY a JSON array of 3 strings. No explanation, no markdown. Example output: ["Sounds good!", "I'll check and get back to you", "Thanks for the update!"]`;
+
+    const contextMessages = (messages || [])
+      .filter((m) => m.text)
+      .map((m) => ({
+        role: m.isMe ? "assistant" : "user",
+        content: m.text,
+      }));
+
+    const response = await fetch(
+      "https://openrouter.ai/api/v1/chat/completions",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${OPENROUTER_API_KEY}`,
+          "Content-Type": "application/json",
+          "HTTP-Referer": process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000",
+          "X-Title": "ConvoX Chat",
+        },
+        body: JSON.stringify({
+          model: MODEL,
+          messages: [
+            { role: "system", content: systemPrompt },
+            ...contextMessages,
+            {
+              role: "user",
+              content: `Suggest 3 short replies to: "${latestMessage}"`,
+            },
+          ],
+          max_tokens: 8192,
+          temperature: 0.7,
+        }),
+      },
+    );
+
+    if (!response.ok) {
+      const errText = await response.text();
+      console.error("[AI route] OpenRouter HTTP", response.status, response.statusText);
+      console.error("[AI route] model:", MODEL);
+      console.error("[AI route] response body:", errText);
+      console.error("[AI route] request headers sent:", {
+        Authorization: `Bearer ${OPENROUTER_API_KEY?.slice(0, 12)}...`,
+        "HTTP-Referer": process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000",
+      });
+      return NextResponse.json({ error: "AI service error" }, { status: 502 });
+    }
+
+    const data = await response.json();
+    console.log("[AI route] OpenRouter response OK");
+    console.log("[AI route] raw data:", JSON.stringify(data, null, 2));
+    const choice = data.choices?.[0]?.message;
+
+    const content = choice?.content?.trim() || "";
+    const reasoning = choice?.reasoning?.trim() || "";
+
+    let suggestions = extractSuggestions(content);
+    if (suggestions.length < 2) {
+      suggestions = extractSuggestions(reasoning);
+    }
+
+    return NextResponse.json({ suggestions });
+  } catch (err) {
+    console.error("[AI route] error:", err);
+    return NextResponse.json(
+      { error: "Failed to generate suggestions" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/ai-rewrite/route.js
+++ b/src/app/api/ai-rewrite/route.js
@@ -1,0 +1,87 @@
+import { NextResponse } from "next/server";
+
+const OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY;
+const MODEL = "nvidia/nemotron-3-super-120b-a12b:free";
+
+export async function POST(req) {
+  if (!OPENROUTER_API_KEY) {
+    return NextResponse.json(
+      { error: "OpenRouter API key not configured" },
+      { status: 500 },
+    );
+  }
+
+  try {
+    const { text, tone } = await req.json();
+
+    // Validate inputs
+    if (!tone?.trim() || tone.trim().length > 30) {
+      return NextResponse.json(
+        { error: "tone must be 1–30 characters" },
+        { status: 400 },
+      );
+    }
+    if (!text?.trim()) {
+      return NextResponse.json(
+        { error: "text must not be empty" },
+        { status: 400 },
+      );
+    }
+
+    const truncatedText = text.slice(0, 2000);
+
+    const response = await fetch(
+      "https://openrouter.ai/api/v1/chat/completions",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${OPENROUTER_API_KEY}`,
+          "Content-Type": "application/json",
+          "HTTP-Referer": process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000",
+          "X-Title": "ConvoX Chat",
+        },
+        body: JSON.stringify({
+          model: MODEL,
+          messages: [
+            {
+              role: "system",
+              content:
+                "You are a message rewriting assistant. Rewrite the user's message in the requested tone. Output ONLY the rewritten message text. No explanation, no introduction, no quotes, no labels. Just the rewritten text.",
+            },
+            {
+              role: "user",
+              content: `Rewrite this message in a ${tone} tone: "${truncatedText}"`,
+            },
+          ],
+          max_tokens: 8192,
+          temperature: 0.4,
+        }),
+      },
+    );
+
+    if (!response.ok) {
+      const errText = await response.text();
+      console.error("[ai-rewrite] OpenRouter error:", response.status, errText);
+      return NextResponse.json({ error: "AI service error" }, { status: 502 });
+    }
+
+    const data = await response.json();
+    const choice = data.choices?.[0]?.message;
+    const content = choice?.content?.trim() || "";
+    const reasoning = choice?.reasoning?.trim() || "";
+
+    // Prefer content; fall back to reasoning (reasoning model may put answer there)
+    let raw = content || reasoning;
+
+    // Strip common leading label patterns the model might add
+    raw = raw.replace(/^(here(?:'s| is)|rewritten(?: version)?|result)[^:]*:\s*/i, "");
+
+    return NextResponse.json({ rewrite: raw.trim() });
+  } catch (err) {
+    console.error("[ai-rewrite] error:", err);
+    return NextResponse.json(
+      { error: "Failed to rewrite message" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/components/ChatDashboard/ChatWindow.jsx
+++ b/src/components/ChatDashboard/ChatWindow.jsx
@@ -95,6 +95,17 @@ export default function ChatWindow({
   const [loadingAiReplies, setLoadingAiReplies] = useState(false);
   const lastAiRepliesForMsgRef = useRef(null);
 
+  // Tone rewrite state
+  const [aiMenuOpen, setAiMenuOpen] = useState(false);
+  const [tonePickerOpen, setTonePickerOpen] = useState(false);
+  const [selectedTone, setSelectedTone] = useState("");
+  const [customTone, setCustomTone] = useState("");
+  const [loadingRewrite, setLoadingRewrite] = useState(false);
+  const [rewritePreview, setRewritePreview] = useState(null);
+  const [originalText, setOriginalText] = useState("");
+  const aiMenuRefDesktop = useRef(null);
+  const aiMenuRefMobile = useRef(null);
+
   // Scheduled messages UI
   const [scheduleMode, setScheduleMode] = useState(false);
   const [sendAt, setSendAt] = useState("");
@@ -151,13 +162,24 @@ export default function ChatWindow({
       if (gifPickerRef.current && !gifPickerRef.current.contains(e.target)) {
         setShowGifPicker(false);
       }
+      // Close AI menu on outside click
+      // A null ref means the element isn't mounted — treat as "outside"
+      const outsideDesktop =
+        !aiMenuRefDesktop.current ||
+        !aiMenuRefDesktop.current.contains(e.target);
+      const outsideMobile =
+        !aiMenuRefMobile.current ||
+        !aiMenuRefMobile.current.contains(e.target);
+      if (aiMenuOpen && outsideDesktop && outsideMobile) {
+        setAiMenuOpen(false);
+      }
     };
 
-    if (reactionPickerMsgId || showEmojiPicker || showGifPicker) {
+    if (reactionPickerMsgId || showEmojiPicker || showGifPicker || aiMenuOpen) {
       document.addEventListener("mousedown", handleClickOutside);
     }
     return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, [reactionPickerMsgId, showEmojiPicker, showGifPicker]);
+  }, [reactionPickerMsgId, showEmojiPicker, showGifPicker, aiMenuOpen]);
 
   const handleEmojiClick = (emojiData) =>
     setText((prev) => prev + emojiData.emoji);
@@ -321,6 +343,14 @@ export default function ChatWindow({
       setShowScheduledPanel(false);
       setAiReplies([]);
       lastAiRepliesForMsgRef.current = null;
+      // Tone rewrite resets
+      setAiMenuOpen(false);
+      setTonePickerOpen(false);
+      setSelectedTone("");
+      setCustomTone("");
+      setLoadingRewrite(false);
+      setRewritePreview(null);
+      setOriginalText("");
 
       try {
         const res = await api.get(`/api/chat/messages/${conversation._id}`);
@@ -549,6 +579,35 @@ export default function ChatWindow({
     fetchAiReplies(visible);
   }, [messages, fetchAiReplies]);
 
+  // activeTone: string primitive — safe to use in useCallback dep array
+  const activeTone = customTone.trim() || selectedTone;
+
+  const handleRewrite = useCallback(async () => {
+    if (!activeTone || !text.trim() || loadingRewrite) return;
+
+    setOriginalText(text);      // capture before call — overwrites any previous value
+    setLoadingRewrite(true);
+    setRewritePreview(null);    // hide stale preview while loading
+
+    try {
+      const res = await fetch("/api/ai-rewrite", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text: text.slice(0, 2000), tone: activeTone }),
+      });
+      const data = await res.json();
+      if (data.rewrite?.trim()) {
+        setRewritePreview(data.rewrite.trim());
+      } else {
+        toast.error("Failed to rewrite message");
+      }
+    } catch {
+      toast.error("Failed to rewrite message");
+    } finally {
+      setLoadingRewrite(false);
+    }
+  }, [text, activeTone, loadingRewrite]);
+
   const onCancelScheduled = async (id) => {
     try {
       await cancelScheduledMessage({ scheduledId: id });
@@ -566,6 +625,15 @@ export default function ChatWindow({
 
   // Scheduled: create
   const scheduleMessage = async () => {
+    // Clear AI state so tone picker/preview don't persist after scheduling
+    setAiMenuOpen(false);
+    setTonePickerOpen(false);
+    setSelectedTone("");
+    setCustomTone("");
+    setLoadingRewrite(false);
+    setRewritePreview(null);
+    setOriginalText("");
+
     if (!text.trim() || !conversation?._id) return;
 
     if (!sendAt) {
@@ -641,6 +709,14 @@ export default function ChatWindow({
     setMessages((prev) => [...prev, optimistic]);
     setText("");
     setAiReplies([]);
+    // Tone rewrite resets
+    setAiMenuOpen(false);
+    setTonePickerOpen(false);
+    setSelectedTone("");
+    setCustomTone("");
+    setLoadingRewrite(false);
+    setRewritePreview(null);
+    setOriginalText("");
     const isGrp = conversation.type === "group";
     socket.emit("typing:stop", {
       conversationId: conversation._id,
@@ -1272,28 +1348,69 @@ export default function ChatWindow({
         onSubmit={handleSend}
         className="p-4 relative z-20 bg-obsidian/80 backdrop-blur-sm border-t border-white/5"
       >
-        {replyTo && (
-          <div className="absolute bottom-full left-0 right-0 p-3 bg-slate-surface border-t border-accent/30 flex items-center justify-between">
-            <div className="flex items-center gap-3 overflow-hidden">
-              <div className="w-1 bg-accent h-8 rounded-full" />
-              <div className="overflow-hidden">
-                <p className="text-[11px] font-bold text-accent">
-                  Replying to {replyTo.sender?.name}
-                </p>
-                <p className="text-xs text-ivory/40 truncate">{replyTo.text}</p>
+        {/* Shared absolute wrapper — rewritePreview and replyTo stack as block elements */}
+        <div className="absolute bottom-full left-0 right-0">
+          {rewritePreview && (
+            <div className="p-3 bg-slate-surface border-t border-accent/30 flex flex-col gap-2">
+              <div className="flex items-center justify-between">
+                <span className="text-[11px] font-bold text-accent">
+                  AI rewrite · {activeTone}
+                </span>
+              </div>
+              <p className="text-sm text-ivory/80 leading-relaxed">{rewritePreview}</p>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => {
+                    setText(rewritePreview);
+                    setRewritePreview(null);
+                    setTonePickerOpen(false);
+                    setSelectedTone("");
+                    setCustomTone("");
+                  }}
+                  className="px-3 py-1 text-[11px] font-bold rounded-lg bg-accent/20 border border-accent/40 text-accent hover:bg-accent/30 transition-all"
+                >
+                  ✓ Use this
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setText(originalText);
+                    setRewritePreview(null);
+                    setTonePickerOpen(false);
+                    setSelectedTone("");
+                    setCustomTone("");
+                  }}
+                  className="px-3 py-1 text-[11px] font-bold rounded-lg bg-white/5 border border-white/10 text-ivory/40 hover:text-ivory/70 transition-all"
+                >
+                  ✗ Discard
+                </button>
               </div>
             </div>
-            <button
-              type="button"
-              onClick={() => setReplyTo(null)}
-              className="p-1.5 hover:bg-white/5 rounded-full text-ivory/30"
-              aria-label="Cancel reply"
-              title="Cancel reply"
-            >
-              <X size={16} />
-            </button>
-          </div>
-        )}
+          )}
+          {replyTo && (
+            <div className="p-3 bg-slate-surface border-t border-accent/30 flex items-center justify-between">
+              <div className="flex items-center gap-3 overflow-hidden">
+                <div className="w-1 bg-accent h-8 rounded-full" />
+                <div className="overflow-hidden">
+                  <p className="text-[11px] font-bold text-accent">
+                    Replying to {replyTo.sender?.name}
+                  </p>
+                  <p className="text-xs text-ivory/40 truncate">{replyTo.text}</p>
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={() => setReplyTo(null)}
+                className="p-1.5 hover:bg-white/5 rounded-full text-ivory/30"
+                aria-label="Cancel reply"
+                title="Cancel reply"
+              >
+                <X size={16} />
+              </button>
+            </div>
+          )}
+        </div>
 
         {showScheduledPanel && (
           <div className="mb-3 p-3 rounded-2xl bg-slate-surface border border-white/5">
@@ -1390,38 +1507,109 @@ export default function ChatWindow({
           </div>
         )}
 
-        {(aiReplies.length > 0 || loadingAiReplies) && (
+        {(aiReplies.length > 0 || loadingAiReplies || tonePickerOpen) && (
           <div className="flex items-center gap-1.5 flex-wrap mb-2 px-1">
-            <span className="text-[9px] text-ivory/20 font-semibold uppercase tracking-wide">
-              AI
-            </span>
-            {loadingAiReplies ? (
-              <div className="flex items-center gap-1.5">
-                <div className="w-3 h-3 rounded-full border-2 border-accent border-t-transparent animate-spin" />
-                <span className="text-[10px] text-ivory/30">Generating replies...</span>
-              </div>
-            ) : (
+            {tonePickerOpen ? (
+              /* ── Tone Picker ── */
               <>
-                {aiReplies.map((reply, i) => (
+                <span className="text-[9px] text-ivory/20 font-semibold uppercase tracking-wide">
+                  Rewrite as:
+                </span>
+                {["Formal", "Casual", "Friendly"].map((tone) => (
                   <button
-                    key={i}
+                    key={tone}
                     type="button"
-                    onClick={() => setText(reply)}
-                    className="px-3 py-1 text-[11px] rounded-full bg-accent/10 border border-accent/20 text-accent/80 hover:bg-accent/20 hover:text-accent transition-all max-w-[180px] truncate"
-                    title={reply}
+                    onClick={() => {
+                      setSelectedTone(tone);
+                      setCustomTone("");
+                    }}
+                    className={`px-3 py-1 text-[11px] rounded-full border transition-all ${
+                      selectedTone === tone && !customTone.trim()
+                        ? "bg-accent/20 border-accent/40 text-accent"
+                        : "bg-accent/10 border-accent/20 text-accent/80 hover:bg-accent/20 hover:text-accent"
+                    }`}
                   >
-                    {reply}
+                    {tone}
                   </button>
                 ))}
+                <input
+                  type="text"
+                  value={customTone}
+                  onChange={(e) => {
+                    setCustomTone(e.target.value);
+                    setSelectedTone("");
+                  }}
+                  maxLength={30}
+                  placeholder="Custom tone..."
+                  className="px-2 py-1 text-[11px] rounded-full bg-white/5 border border-white/10 text-ivory/60 placeholder:text-ivory/20 outline-none focus:border-accent/30 max-w-[120px]"
+                />
                 <button
                   type="button"
-                  onClick={() => setAiReplies([])}
+                  onClick={handleRewrite}
+                  disabled={!activeTone || loadingRewrite}
+                  className={`flex items-center gap-1 px-3 py-1 text-[11px] font-bold rounded-full border transition-all ${
+                    !activeTone || loadingRewrite
+                      ? "bg-white/5 border-white/10 text-ivory/20 cursor-not-allowed"
+                      : "bg-accent/20 border-accent/40 text-accent hover:bg-accent/30"
+                  }`}
+                >
+                  {loadingRewrite ? (
+                    <span className="w-2.5 h-2.5 rounded-full border-2 border-accent border-t-transparent animate-spin" />
+                  ) : (
+                    "Rewrite →"
+                  )}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setTonePickerOpen(false);
+                    setSelectedTone("");
+                    setCustomTone("");
+                    setRewritePreview(null);
+                    setOriginalText("");
+                  }}
                   className="ml-auto p-0.5 text-ivory/20 hover:text-ivory/50 transition-colors"
-                  title="Dismiss suggestions"
-                  aria-label="Dismiss AI suggestions"
+                  title="Dismiss tone picker"
+                  aria-label="Dismiss tone picker"
                 >
                   <X size={11} />
                 </button>
+              </>
+            ) : (
+              /* ── AI Reply Chips ── */
+              <>
+                <span className="text-[9px] text-ivory/20 font-semibold uppercase tracking-wide">
+                  AI
+                </span>
+                {loadingAiReplies ? (
+                  <div className="flex items-center gap-1.5">
+                    <div className="w-3 h-3 rounded-full border-2 border-accent border-t-transparent animate-spin" />
+                    <span className="text-[10px] text-ivory/30">Generating replies...</span>
+                  </div>
+                ) : (
+                  <>
+                    {aiReplies.map((reply, i) => (
+                      <button
+                        key={i}
+                        type="button"
+                        onClick={() => setText(reply)}
+                        className="px-3 py-1 text-[11px] rounded-full bg-accent/10 border border-accent/20 text-accent/80 hover:bg-accent/20 hover:text-accent transition-all max-w-[180px] truncate"
+                        title={reply}
+                      >
+                        {reply}
+                      </button>
+                    ))}
+                    <button
+                      type="button"
+                      onClick={() => setAiReplies([])}
+                      className="ml-auto p-0.5 text-ivory/20 hover:text-ivory/50 transition-colors"
+                      title="Dismiss suggestions"
+                      aria-label="Dismiss AI suggestions"
+                    >
+                      <X size={11} />
+                    </button>
+                  </>
+                )}
               </>
             )}
           </div>
@@ -1481,26 +1669,54 @@ export default function ChatWindow({
             GIF
           </button>
 
-          <button
-            type="button"
-            onClick={handleAiButton}
-            disabled={loadingAiReplies}
-            title="AI reply suggestions"
-            aria-label="AI reply suggestions"
-            className={`hidden sm:inline-flex items-center gap-1 px-2 py-1 mx-1 text-[10px] font-black rounded-md border transition-all ${
-              loadingAiReplies
-                ? "bg-accent/20 border-accent/40 text-accent cursor-not-allowed"
-                : aiReplies.length > 0
+          <div ref={aiMenuRefDesktop} className="relative hidden sm:inline-flex">
+            <button
+              type="button"
+              onClick={() => setAiMenuOpen((v) => !v)}
+              title="AI tools"
+              aria-label="AI tools"
+              className={`inline-flex items-center gap-1 px-2 py-1 mx-1 text-[10px] font-black rounded-md border transition-all ${
+                aiMenuOpen
                   ? "bg-accent/20 border-accent/40 text-accent"
-                  : "bg-white/4 border-white/10 text-ivory/30 hover:bg-accent/10 hover:border-accent/30 hover:text-accent"
-            }`}
-          >
-            {loadingAiReplies ? (
-              <span className="w-2.5 h-2.5 rounded-full border-2 border-accent border-t-transparent animate-spin" />
-            ) : (
-              "✦ AI"
+                  : aiReplies.length > 0 || tonePickerOpen
+                    ? "bg-accent/20 border-accent/40 text-accent"
+                    : "bg-white/4 border-white/10 text-ivory/30 hover:bg-accent/10 hover:border-accent/30 hover:text-accent"
+              }`}
+            >
+              ✦ AI
+            </button>
+            {aiMenuOpen && (
+              <div className="absolute bottom-full mb-1 right-0 w-44 bg-deep border border-white/10 rounded-lg shadow-lg overflow-hidden z-50">
+                <button
+                  type="button"
+                  className="w-full text-left px-3 py-2 text-[11px] text-ivory/70 hover:bg-white/6 hover:text-ivory transition-colors"
+                  onClick={() => {
+                    setAiMenuOpen(false);
+                    handleAiButton();
+                  }}
+                >
+                  Reply suggestions
+                </button>
+                <button
+                  type="button"
+                  disabled={!text.trim()}
+                  className={`w-full text-left px-3 py-2 text-[11px] transition-colors ${
+                    text.trim()
+                      ? "text-ivory/70 hover:bg-white/6 hover:text-ivory"
+                      : "text-ivory/20 opacity-40 cursor-not-allowed"
+                  }`}
+                  onClick={() => {
+                    if (!text.trim()) return;
+                    setAiMenuOpen(false);
+                    setAiReplies([]);
+                    setTonePickerOpen(true);
+                  }}
+                >
+                  Rewrite tone
+                </button>
+              </div>
             )}
-          </button>
+          </div>
 
           {!isGroup && (
             <button
@@ -1596,26 +1812,54 @@ export default function ChatWindow({
               GIF
             </button>
 
-            <button
-              type="button"
-              onClick={handleAiButton}
-              disabled={loadingAiReplies}
-              title="AI reply suggestions"
-              aria-label="AI reply suggestions"
-              className={`inline-flex items-center gap-1 px-2 py-1 text-[10px] font-black rounded-md border transition-all ${
-                loadingAiReplies
-                  ? "bg-accent/20 border-accent/40 text-accent cursor-not-allowed"
-                  : aiReplies.length > 0
+            <div ref={aiMenuRefMobile} className="relative inline-flex">
+              <button
+                type="button"
+                onClick={() => setAiMenuOpen((v) => !v)}
+                title="AI tools"
+                aria-label="AI tools"
+                className={`inline-flex items-center gap-1 px-2 py-1 text-[10px] font-black rounded-md border transition-all ${
+                  aiMenuOpen
                     ? "bg-accent/20 border-accent/40 text-accent"
-                    : "bg-white/4 border-white/10 text-ivory/30 hover:bg-accent/10 hover:border-accent/30 hover:text-accent"
-              }`}
-            >
-              {loadingAiReplies ? (
-                <span className="w-2.5 h-2.5 rounded-full border-2 border-accent border-t-transparent animate-spin" />
-              ) : (
-                "✦ AI"
+                    : aiReplies.length > 0 || tonePickerOpen
+                      ? "bg-accent/20 border-accent/40 text-accent"
+                      : "bg-white/4 border-white/10 text-ivory/30 hover:bg-accent/10 hover:border-accent/30 hover:text-accent"
+                }`}
+              >
+                ✦ AI
+              </button>
+              {aiMenuOpen && (
+                <div className="absolute bottom-full mb-1 right-0 w-44 bg-deep border border-white/10 rounded-lg shadow-lg overflow-hidden z-50">
+                  <button
+                    type="button"
+                    className="w-full text-left px-3 py-2 text-[11px] text-ivory/70 hover:bg-white/6 hover:text-ivory transition-colors"
+                    onClick={() => {
+                      setAiMenuOpen(false);
+                      handleAiButton();
+                    }}
+                  >
+                    Reply suggestions
+                  </button>
+                  <button
+                    type="button"
+                    disabled={!text.trim()}
+                    className={`w-full text-left px-3 py-2 text-[11px] transition-colors ${
+                      text.trim()
+                        ? "text-ivory/70 hover:bg-white/6 hover:text-ivory"
+                        : "text-ivory/20 opacity-40 cursor-not-allowed"
+                    }`}
+                    onClick={() => {
+                      if (!text.trim()) return;
+                      setAiMenuOpen(false);
+                      setAiReplies([]);
+                      setTonePickerOpen(true);
+                    }}
+                  >
+                    Rewrite tone
+                  </button>
+                </div>
               )}
-            </button>
+            </div>
 
             {!isGroup && (
               <button

--- a/src/components/ChatDashboard/ChatWindow.jsx
+++ b/src/components/ChatDashboard/ChatWindow.jsx
@@ -91,6 +91,10 @@ export default function ChatWindow({
   const [suggestions, setSuggestions] = useState([]);
   const [suggestionIndex, setSuggestionIndex] = useState(0);
 
+  const [aiReplies, setAiReplies] = useState([]);
+  const [loadingAiReplies, setLoadingAiReplies] = useState(false);
+  const lastAiRepliesForMsgRef = useRef(null);
+
   // Scheduled messages UI
   const [scheduleMode, setScheduleMode] = useState(false);
   const [sendAt, setSendAt] = useState("");
@@ -315,6 +319,8 @@ export default function ChatWindow({
       setLongPressedMsgId(null);
       setScheduleMode(false);
       setShowScheduledPanel(false);
+      setAiReplies([]);
+      lastAiRepliesForMsgRef.current = null;
 
       try {
         const res = await api.get(`/api/chat/messages/${conversation._id}`);
@@ -469,6 +475,47 @@ export default function ChatWindow({
     bottomRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages]);
 
+  const fetchAiReplies = useCallback(
+    async (messagesList) => {
+      const visible = messagesList
+        .filter((m) => !m.isOptimistic && !m.isDeleted && m.text?.trim())
+        .slice(-10);
+
+      if (visible.length === 0) return;
+
+      const lastMsg = visible[visible.length - 1];
+
+      setLoadingAiReplies(true);
+      setAiReplies([]);
+
+      try {
+        const context = visible.slice(0, -1).map((m) => ({
+          text: m.text,
+          isMe: (m.sender?._id ?? m.sender) === user?._id,
+        }));
+
+        const res = await fetch("/api/ai-reply", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            messages: context,
+            latestMessage: lastMsg.text,
+          }),
+        });
+
+        const data = await res.json();
+        if (Array.isArray(data.suggestions) && data.suggestions.length > 0) {
+          setAiReplies(data.suggestions.slice(0, 3));
+        }
+      } catch (err) {
+        console.error("[AI] fetchAiReplies error:", err);
+      } finally {
+        setLoadingAiReplies(false);
+      }
+    },
+    [user?._id],
+  );
+
   // Scheduled: refresh list
   const refreshScheduled = useCallback(async () => {
     if (!conversation?._id) return;
@@ -494,6 +541,13 @@ export default function ChatWindow({
     if (!conversation?._id) return;
     refreshScheduled();
   }, [conversation?._id, refreshScheduled]);
+
+  const handleAiButton = useCallback(() => {
+    const visible = messages.filter(
+      (m) => !m.isOptimistic && !m.isDeleted && m.text?.trim(),
+    );
+    fetchAiReplies(visible);
+  }, [messages, fetchAiReplies]);
 
   const onCancelScheduled = async (id) => {
     try {
@@ -586,6 +640,7 @@ export default function ChatWindow({
 
     setMessages((prev) => [...prev, optimistic]);
     setText("");
+    setAiReplies([]);
     const isGrp = conversation.type === "group";
     socket.emit("typing:stop", {
       conversationId: conversation._id,
@@ -1335,6 +1390,43 @@ export default function ChatWindow({
           </div>
         )}
 
+        {(aiReplies.length > 0 || loadingAiReplies) && (
+          <div className="flex items-center gap-1.5 flex-wrap mb-2 px-1">
+            <span className="text-[9px] text-ivory/20 font-semibold uppercase tracking-wide">
+              AI
+            </span>
+            {loadingAiReplies ? (
+              <div className="flex items-center gap-1.5">
+                <div className="w-3 h-3 rounded-full border-2 border-accent border-t-transparent animate-spin" />
+                <span className="text-[10px] text-ivory/30">Generating replies...</span>
+              </div>
+            ) : (
+              <>
+                {aiReplies.map((reply, i) => (
+                  <button
+                    key={i}
+                    type="button"
+                    onClick={() => setText(reply)}
+                    className="px-3 py-1 text-[11px] rounded-full bg-accent/10 border border-accent/20 text-accent/80 hover:bg-accent/20 hover:text-accent transition-all max-w-[180px] truncate"
+                    title={reply}
+                  >
+                    {reply}
+                  </button>
+                ))}
+                <button
+                  type="button"
+                  onClick={() => setAiReplies([])}
+                  className="ml-auto p-0.5 text-ivory/20 hover:text-ivory/50 transition-colors"
+                  title="Dismiss suggestions"
+                  aria-label="Dismiss AI suggestions"
+                >
+                  <X size={11} />
+                </button>
+              </>
+            )}
+          </div>
+        )}
+
         <div className="bg-slate-surface rounded-2xl flex items-center flex-wrap p-2 gap-1 border border-white/5 focus-within:border-accent/50 transition-all shadow-inner">
           <button
             type="button"
@@ -1387,6 +1479,27 @@ export default function ChatWindow({
             }`}
           >
             GIF
+          </button>
+
+          <button
+            type="button"
+            onClick={handleAiButton}
+            disabled={loadingAiReplies}
+            title="AI reply suggestions"
+            aria-label="AI reply suggestions"
+            className={`hidden sm:inline-flex items-center gap-1 px-2 py-1 mx-1 text-[10px] font-black rounded-md border transition-all ${
+              loadingAiReplies
+                ? "bg-accent/20 border-accent/40 text-accent cursor-not-allowed"
+                : aiReplies.length > 0
+                  ? "bg-accent/20 border-accent/40 text-accent"
+                  : "bg-white/4 border-white/10 text-ivory/30 hover:bg-accent/10 hover:border-accent/30 hover:text-accent"
+            }`}
+          >
+            {loadingAiReplies ? (
+              <span className="w-2.5 h-2.5 rounded-full border-2 border-accent border-t-transparent animate-spin" />
+            ) : (
+              "✦ AI"
+            )}
           </button>
 
           {!isGroup && (
@@ -1481,6 +1594,27 @@ export default function ChatWindow({
               }`}
             >
               GIF
+            </button>
+
+            <button
+              type="button"
+              onClick={handleAiButton}
+              disabled={loadingAiReplies}
+              title="AI reply suggestions"
+              aria-label="AI reply suggestions"
+              className={`inline-flex items-center gap-1 px-2 py-1 text-[10px] font-black rounded-md border transition-all ${
+                loadingAiReplies
+                  ? "bg-accent/20 border-accent/40 text-accent cursor-not-allowed"
+                  : aiReplies.length > 0
+                    ? "bg-accent/20 border-accent/40 text-accent"
+                    : "bg-white/4 border-white/10 text-ivory/30 hover:bg-accent/10 hover:border-accent/30 hover:text-accent"
+              }`}
+            >
+              {loadingAiReplies ? (
+                <span className="w-2.5 h-2.5 rounded-full border-2 border-accent border-t-transparent animate-spin" />
+              ) : (
+                "✦ AI"
+              )}
             </button>
 
             {!isGroup && (


### PR DESCRIPTION
feat: AI reply suggestions + AI tone rewrite

## Summary

- **AI Reply Suggestions** — a ✨AI button in the chat toolbar calls OpenRouter (`nvidia/nemotron-3-super-120b-a12b:free`) and surfaces 3 short reply chips above the input bar when the other party sends a message. Clicking a chip populates the input; ✕ dismisses.

- **AI Tone Rewrite** — the ✨AI button is now a dropdown menu. Selecting **"Rewrite tone"** opens a tone picker (**Formal / Casual / Friendly** presets + free-text custom up to 30 chars). On submit, the current message is rewritten by AI and shown in a preview panel with **Accept** and **Discard** actions. The original draft is preserved until explicitly accepted or discarded.

---

## Changes

| File | Change |
|-----|------|
| `src/app/api/ai-reply/route.js` | New — OpenRouter route for reply suggestions; **3-strategy extraction** (JSON array → quoted strings → numbered list); reads both `content` and `reasoning` fields from the reasoning model |
| `src/app/api/ai-rewrite/route.js` | New — OpenRouter route for tone rewrite; validates tone (1–30 chars) and text; strips leading label patterns from model output |
| `src/components/ChatDashboard/ChatWindow.jsx` | ✨AI button → dropdown menu (desktop + mobile); tone picker UI in chips area; rewrite preview panel stacked with reply-to panel; `handleRewrite` callback; **7 new state vars + 2 refs**; resets on send and conversation switch |

---

## Notes

- `max_tokens: 8192` is required — the **nvidia/nemotron** model writes chain-of-thought into `reasoning` and needs the headroom. **Do not lower this value.**

- `OPENROUTER_API_KEY` must be set in  
  `chat-app-client/.env.local`  
  (server-side only, **no `NEXT_PUBLIC_` prefix**).

- Outside-click handling uses two separate refs  
  (`aiMenuRefDesktop` / `aiMenuRefMobile`) with **null-safe checks** so desktop/mobile elements don't interfere with each other.