### PR TITLE
feat: implement user profile , user follow and Public User Profiles for feed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1609,7 +1608,6 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -2070,7 +2068,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2413,7 +2410,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2541,8 +2537,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/daisyui": {
       "version": "5.5.19",
@@ -2988,7 +2983,6 @@
       "integrity": "sha512-uYixubwmqJZH+KLVYIVKY1JQt7tysXhtj21WSvjcSmU5SVNzMus1bgLe+pAt816yQ8opKfheVVoPLqvVMGejYw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -3107,7 +3101,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5442,7 +5435,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5452,7 +5444,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6195,7 +6186,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6643,7 +6633,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/app/(site)/layout.jsx
+++ b/src/app/(site)/layout.jsx
@@ -1,12 +1,5 @@
-import NavBar from "@/components/NavBar";
-import Footer from "@/components/Footer";
+import { FeedProvider } from "@/context/FeedProvider";
 
 export default function SiteLayout({ children }) {
-  return (
-    <>
-      <NavBar />
-      {children}
-      <Footer />
-    </>
-  );
+  return <FeedProvider>{children}</FeedProvider>;
 }

--- a/src/app/(site)/layout.jsx
+++ b/src/app/(site)/layout.jsx
@@ -1,5 +1,13 @@
+import NavBar from "@/components/NavBar";
+import Footer from "@/components/Footer";
 import { FeedProvider } from "@/context/FeedProvider";
 
 export default function SiteLayout({ children }) {
-  return <FeedProvider>{children}</FeedProvider>;
+  return (
+    <FeedProvider>
+      <NavBar />
+      {children}
+      <Footer />
+    </FeedProvider>
+  );
 }

--- a/src/app/(site)/profile/[id]/page.jsx
+++ b/src/app/(site)/profile/[id]/page.jsx
@@ -106,7 +106,7 @@ function PublicProfilePage() {
   // ── Load posts ─────────────────────────────────────────────────────────────
   const loadPosts = useCallback(
     async (page = 1) => {
-      if (!profileId) return;
+      if (!profileId) return false;
       setLoadingPosts(true);
       try {
         const data = await getUserPosts(profileId, page);
@@ -116,8 +116,10 @@ function PublicProfilePage() {
           setPosts((prev) => [...prev, ...(data.posts || [])]);
         }
         setHasMorePosts(data.hasMore ?? false);
-      } catch {
-        // silently fail — posts section shows empty state
+        return true;
+      } catch (err) {
+        console.error("loadPosts error:", err?.message);
+        return false;
       } finally {
         setLoadingPosts(false);
       }
@@ -178,10 +180,16 @@ function PublicProfilePage() {
     );
   }
 
-  if (!profile) {
+  if (!profile && !loadingProfile) {
     return (
       <div className="min-h-screen bg-obsidian pt-20 flex items-center justify-center">
-        <p className="text-ivory/30 font-mono text-sm">Profile not found.</p>
+        <p className="text-ivory/30 font-mono text-sm">
+          {profileError === "notfound"
+            ? "Profile not found."
+            : profileError === "error"
+              ? "Could not load profile. Please try again."
+              : "Profile not found."}
+        </p>
       </div>
     );
   }
@@ -366,8 +374,8 @@ function PublicProfilePage() {
                       <button
                         onClick={async () => {
                           const next = postsPage + 1;
-                          await loadPosts(next);
-                          setPostsPage(next);
+                          const ok = await loadPosts(next);
+                          if (ok) setPostsPage(next);
                         }}
                         disabled={loadingPosts}
                         className="w-full py-2 text-[12px] font-mono text-ivory/30 hover:text-ivory/60 transition-colors flex items-center justify-center gap-2"

--- a/src/app/(site)/profile/[id]/page.jsx
+++ b/src/app/(site)/profile/[id]/page.jsx
@@ -75,6 +75,13 @@ function PublicProfilePage() {
     if (!profileId) return;
     let cancelled = false;
 
+    // Reset stale state before loading new profile
+    setProfile(null);
+    setFollowing(false);
+    setPosts([]);
+    setPostsPage(1);
+    setHasMorePosts(false);
+
     const load = async () => {
       setLoadingProfile(true);
       try {
@@ -357,10 +364,10 @@ function PublicProfilePage() {
                     ))}
                     {hasMorePosts && (
                       <button
-                        onClick={() => {
+                        onClick={async () => {
                           const next = postsPage + 1;
+                          await loadPosts(next);
                           setPostsPage(next);
-                          loadPosts(next);
                         }}
                         disabled={loadingPosts}
                         className="w-full py-2 text-[12px] font-mono text-ivory/30 hover:text-ivory/60 transition-colors flex items-center justify-center gap-2"

--- a/src/app/(site)/profile/[id]/page.jsx
+++ b/src/app/(site)/profile/[id]/page.jsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect, useCallback } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { useParams } from "next/navigation";
@@ -15,75 +15,16 @@ import {
   MessageSquare,
   UserPlus,
   UserCheck,
-  MapPin,
+  Loader2,
 } from "lucide-react";
+import toast from "react-hot-toast";
 import ProtectedRoute from "@/components/auth/ProtectedRoute";
 import useAuth from "@/hooks/useAuth";
+import useFeed from "@/hooks/useFeed";
 import ReputationBadge, { getLevel } from "@/components/Feed/ReputationBadge";
 import PostCard from "@/components/Feed/PostCard";
 import TagChip from "@/components/Feed/TagChip";
 
-// ── Design-phase mock profile ─────────────────────────────────────────────────
-const MOCK_PROFILE = {
-  _id: "u1",
-  name: "Alex Kim",
-  avatar: null,
-  bio: "Full-stack dev obsessed with DX and performance. Building cool things with TypeScript, Rust, and WebAssembly.",
-  location: "Seoul, South Korea",
-  website: "https://alexkim.dev",
-  provider: "github",
-  reputation: 820,
-  following: ["u2", "u3"],
-  followers: ["u2", "u3", "u4", "u5", "u6"],
-  followedTags: ["typescript", "rust", "webassembly"],
-  createdAt: "2024-01-15T00:00:00.000Z",
-};
-
-const MOCK_POSTS = [
-  {
-    _id: "p1",
-    type: "showcase",
-    title:
-      "Built a real-time collaborative whiteboard with WebRTC + Canvas API",
-    content:
-      "Spent the last 3 weekends on this. P2P signalling via a small Socket.io relay, all drawing state sync'd via CRDT-lite.",
-    author: MOCK_PROFILE,
-    tags: ["webrtc", "canvas", "showcase"],
-    reactions: { "🔥": ["u2", "u3", "u4", "u5"], "🚀": ["u6"] },
-    commentCount: 11,
-    views: 312,
-    isPinned: true,
-    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 6).toISOString(),
-  },
-  {
-    _id: "p2",
-    type: "question",
-    title: "What's the best way to manage global state in Next.js 14?",
-    content: "I've been juggling between Zustand, Jotai, and the Context API.",
-    author: MOCK_PROFILE,
-    tags: ["nextjs", "react", "state"],
-    reactions: { "🔥": ["u2", "u3"], "💡": ["u4"] },
-    commentCount: 7,
-    views: 142,
-    isPinned: false,
-    isResolved: false,
-    acceptedAnswer: null,
-    createdAt: new Date(Date.now() - 1000 * 60 * 37).toISOString(),
-  },
-];
-
-const MOCK_ACCEPTED_ANSWERS = [
-  {
-    _id: "c1",
-    post: { title: "How do I debounce inputs in React?" },
-    content:
-      "Use `useCallback` + a `useEffect` with `setTimeout` — or just reach for `use-debounce` from npm for convenience.",
-    reactions: { "👏": ["u2", "u3"] },
-    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 48).toISOString(),
-  },
-];
-
-// ── Page tabs ─────────────────────────────────────────────────────────────────
 const TABS = [
   { id: "posts", label: "Posts", icon: FileText },
   { id: "answers", label: "Answers", icon: MessageSquare },
@@ -100,7 +41,6 @@ function formatJoined(dateStr) {
   }
 }
 
-// ── Stat pill ─────────────────────────────────────────────────────────────────
 function StatPill({ value, label }) {
   return (
     <div className="flex flex-col items-center px-4 py-2">
@@ -114,16 +54,133 @@ function StatPill({ value, label }) {
   );
 }
 
-// ── Main Page ─────────────────────────────────────────────────────────────────
 function PublicProfilePage() {
   const params = useParams();
+  const profileId = params?.id;
   const { user: me } = useAuth();
-  const [activeTab, setActiveTab] = useState("posts");
-  const [following, setFollowing] = useState(false); // TODO: derive from me.following.includes(params.id)
+  const { getUserProfile, getUserPosts, followUser } = useFeed();
 
-  // Design-phase: always show mock profile
-  const profile = MOCK_PROFILE;
-  const isOwnProfile = profile._id === me?._id;
+  const [activeTab, setActiveTab] = useState("posts");
+  const [profile, setProfile] = useState(null);
+  const [posts, setPosts] = useState([]);
+  const [loadingProfile, setLoadingProfile] = useState(true);
+  const [loadingPosts, setLoadingPosts] = useState(false);
+  const [following, setFollowing] = useState(false);
+  const [followLoading, setFollowLoading] = useState(false);
+  const [postsPage, setPostsPage] = useState(1);
+  const [hasMorePosts, setHasMorePosts] = useState(false);
+
+  // ── Load profile ───────────────────────────────────────────────────────────
+  useEffect(() => {
+    if (!profileId) return;
+    let cancelled = false;
+
+    const load = async () => {
+      setLoadingProfile(true);
+      try {
+        const data = await getUserProfile(profileId);
+        if (!cancelled) {
+          setProfile(data);
+          setFollowing(data.isFollowing);
+        }
+      } catch {
+        if (!cancelled) toast.error("Could not load profile");
+      } finally {
+        if (!cancelled) setLoadingProfile(false);
+      }
+    };
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [profileId, getUserProfile]);
+
+  // ── Load posts ─────────────────────────────────────────────────────────────
+  const loadPosts = useCallback(
+    async (page = 1) => {
+      if (!profileId) return;
+      setLoadingPosts(true);
+      try {
+        const data = await getUserPosts(profileId, page);
+        if (page === 1) {
+          setPosts(data.posts || []);
+        } else {
+          setPosts((prev) => [...prev, ...(data.posts || [])]);
+        }
+        setHasMorePosts(data.hasMore ?? false);
+      } catch {
+        // silently fail — posts section shows empty state
+      } finally {
+        setLoadingPosts(false);
+      }
+    },
+    [profileId, getUserPosts],
+  );
+
+  useEffect(() => {
+    if (activeTab === "posts") {
+      setPostsPage(1);
+      loadPosts(1);
+    }
+  }, [activeTab, loadPosts]);
+
+  // ── Follow toggle ──────────────────────────────────────────────────────────
+  const handleFollow = async () => {
+    if (followLoading) return;
+    setFollowLoading(true);
+    const prev = following;
+
+    // Optimistic
+    setFollowing(!prev);
+    setProfile((p) =>
+      p
+        ? {
+            ...p,
+            followersCount: (p.followersCount ?? 0) + (prev ? -1 : 1),
+            isFollowing: !prev,
+          }
+        : p,
+    );
+
+    try {
+      await followUser(profileId);
+    } catch {
+      setFollowing(prev);
+      setProfile((p) =>
+        p
+          ? {
+              ...p,
+              followersCount: (p.followersCount ?? 0) + (prev ? 1 : -1),
+              isFollowing: prev,
+            }
+          : p,
+      );
+      toast.error("Could not update follow status");
+    } finally {
+      setFollowLoading(false);
+    }
+  };
+
+  // ── Loading / error states ─────────────────────────────────────────────────
+  if (loadingProfile) {
+    return (
+      <div className="min-h-screen bg-obsidian pt-20 flex items-center justify-center">
+        <Loader2 size={32} className="text-accent/40 animate-spin" />
+      </div>
+    );
+  }
+
+  if (!profile) {
+    return (
+      <div className="min-h-screen bg-obsidian pt-20 flex items-center justify-center">
+        <p className="text-ivory/30 font-mono text-sm">Profile not found.</p>
+      </div>
+    );
+  }
+
+  const isOwnProfile =
+    profile.isOwnProfile || profile._id?.toString() === (me?._id ?? me?.id);
   const level = getLevel(profile.reputation);
 
   const ProviderIcon =
@@ -135,7 +192,7 @@ function PublicProfilePage() {
 
   return (
     <div className="min-h-screen bg-obsidian pt-20 pb-16">
-      {/* ── Back link ── */}
+      {/* Back link */}
       <div className="max-w-4xl mx-auto px-4 mb-6">
         <Link
           href="/app/feed"
@@ -191,23 +248,28 @@ function PublicProfilePage() {
                 </div>
               </div>
 
-              {/* Follow button */}
-              {!isOwnProfile && (
+              {/* Follow / Edit */}
+              {!isOwnProfile ? (
                 <button
                   type="button"
-                  onClick={() => setFollowing((f) => !f)}
-                  className={`flex items-center gap-1.5 px-4 py-2 rounded-xl text-[12px] font-mono font-bold transition-all duration-200 ${
+                  onClick={handleFollow}
+                  disabled={followLoading}
+                  className={`flex items-center gap-1.5 px-4 py-2 rounded-xl text-[12px] font-mono font-bold transition-all duration-200 disabled:opacity-50 ${
                     following
                       ? "bg-accent/12 ring-1 ring-accent/25 text-accent hover:bg-accent/20"
                       : "bg-white/[0.06] ring-1 ring-white/[0.10] text-ivory/60 hover:text-ivory hover:bg-white/[0.10]"
                   }`}
                 >
-                  {following ? <UserCheck size={13} /> : <UserPlus size={13} />}
+                  {followLoading ? (
+                    <Loader2 size={13} className="animate-spin" />
+                  ) : following ? (
+                    <UserCheck size={13} />
+                  ) : (
+                    <UserPlus size={13} />
+                  )}
                   {following ? "Following" : "Follow"}
                 </button>
-              )}
-
-              {isOwnProfile && (
+              ) : (
                 <Link
                   href="/profile"
                   className="flex items-center gap-1.5 px-4 py-2 rounded-xl text-[12px] font-mono font-bold bg-white/[0.06] ring-1 ring-white/[0.10] text-ivory/60 hover:text-ivory hover:bg-white/[0.10] transition-all"
@@ -217,31 +279,13 @@ function PublicProfilePage() {
               )}
             </div>
 
-            {/* Bio */}
             {profile.bio && (
               <p className="text-[13px] text-ivory/60 font-sans leading-relaxed">
                 {profile.bio}
               </p>
             )}
 
-            {/* Meta row */}
             <div className="flex items-center gap-4 flex-wrap text-[11px] font-mono text-ivory/30">
-              {profile.location && (
-                <span className="flex items-center gap-1">
-                  <MapPin size={11} /> {profile.location}
-                </span>
-              )}
-              {profile.website && (
-                <a
-                  href={profile.website}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="flex items-center gap-1 hover:text-accent/70 transition-colors"
-                >
-                  <Globe size={11} />{" "}
-                  {profile.website.replace(/^https?:\/\//, "")}
-                </a>
-              )}
               {profile.createdAt && (
                 <span className="flex items-center gap-1">
                   <Calendar size={11} /> Joined{" "}
@@ -250,7 +294,6 @@ function PublicProfilePage() {
               )}
             </div>
 
-            {/* Followed tags */}
             {(profile.followedTags?.length ?? 0) > 0 && (
               <div className="flex items-center gap-1.5 flex-wrap">
                 {profile.followedTags.map((tag) => (
@@ -263,16 +306,14 @@ function PublicProfilePage() {
 
         {/* ── Stats row ── */}
         <div className="glass-card rounded-2xl flex items-center divide-x divide-white/[0.06]">
-          <StatPill value={MOCK_POSTS.length} label="Posts" />
-          <StatPill value={profile.followers?.length ?? 0} label="Followers" />
-          <StatPill value={profile.following?.length ?? 0} label="Following" />
-          <StatPill value={MOCK_ACCEPTED_ANSWERS.length} label="Answers" />
-          <StatPill value={profile.reputation} label="Rep" />
+          <StatPill value={profile.postCount ?? 0} label="Posts" />
+          <StatPill value={profile.followersCount ?? 0} label="Followers" />
+          <StatPill value={profile.followingCount ?? 0} label="Following" />
+          <StatPill value={profile.reputation ?? 0} label="Rep" />
         </div>
 
-        {/* ── Tabs + content ── */}
+        {/* ── Tabs ── */}
         <div className="glass-card rounded-2xl overflow-hidden">
-          {/* Tab bar */}
           <div className="flex border-b border-white/[0.06] px-4 pt-2">
             {TABS.map(({ id, label, icon: Icon }) => (
               <button
@@ -290,53 +331,57 @@ function PublicProfilePage() {
             ))}
           </div>
 
-          {/* Tab content */}
           <div className="p-4 flex flex-col gap-3">
+            {/* Posts tab */}
             {activeTab === "posts" && (
               <>
-                {MOCK_POSTS.length === 0 ? (
+                {loadingPosts && posts.length === 0 ? (
+                  <div className="flex justify-center py-10">
+                    <Loader2
+                      size={24}
+                      className="text-accent/40 animate-spin"
+                    />
+                  </div>
+                ) : posts.length === 0 ? (
                   <p className="text-center text-[12px] font-mono text-ivory/20 py-10">
                     No posts yet.
                   </p>
                 ) : (
-                  MOCK_POSTS.map((post) => (
-                    <PostCard
-                      key={post._id}
-                      post={post}
-                      currentUserId={me?._id ?? ""}
-                    />
-                  ))
+                  <>
+                    {posts.map((post) => (
+                      <PostCard
+                        key={post._id}
+                        post={post}
+                        currentUserId={me?._id ?? me?.id ?? ""}
+                      />
+                    ))}
+                    {hasMorePosts && (
+                      <button
+                        onClick={() => {
+                          const next = postsPage + 1;
+                          setPostsPage(next);
+                          loadPosts(next);
+                        }}
+                        disabled={loadingPosts}
+                        className="w-full py-2 text-[12px] font-mono text-ivory/30 hover:text-ivory/60 transition-colors flex items-center justify-center gap-2"
+                      >
+                        {loadingPosts ? (
+                          <Loader2 size={13} className="animate-spin" />
+                        ) : (
+                          "Load more"
+                        )}
+                      </button>
+                    )}
+                  </>
                 )}
               </>
             )}
 
+            {/* Answers tab */}
             {activeTab === "answers" && (
-              <>
-                {MOCK_ACCEPTED_ANSWERS.length === 0 ? (
-                  <p className="text-center text-[12px] font-mono text-ivory/20 py-10">
-                    No accepted answers yet.
-                  </p>
-                ) : (
-                  MOCK_ACCEPTED_ANSWERS.map((ans) => (
-                    <div
-                      key={ans._id}
-                      className="glass-card rounded-xl p-4 flex flex-col gap-2"
-                    >
-                      <p className="text-[10px] font-mono text-emerald-400/60 uppercase tracking-wider">
-                        ✓ Accepted Answer
-                      </p>
-                      {ans.post?.title && (
-                        <p className="text-[12px] font-mono text-ivory/30 italic">
-                          On: {ans.post.title}
-                        </p>
-                      )}
-                      <p className="text-[13px] text-ivory/70 font-sans leading-relaxed">
-                        {ans.content}
-                      </p>
-                    </div>
-                  ))
-                )}
-              </>
+              <p className="text-center text-[12px] font-mono text-ivory/20 py-10">
+                Accepted answers coming soon.
+              </p>
             )}
           </div>
         </div>

--- a/src/app/(site)/profile/page.jsx
+++ b/src/app/(site)/profile/page.jsx
@@ -1,6 +1,8 @@
 "use client";
 
-import React, { useState, useRef } from "react";
+import React, { useState, useRef, useEffect, useCallback } from "react";
+import { useSearchParams } from "next/navigation";
+import api from "@/app/api/Axios";
 import Image from "next/image";
 import Link from "next/link";
 import ProtectedRoute from "@/components/auth/ProtectedRoute";
@@ -91,70 +93,6 @@ function StrengthBar({ password }) {
   );
 }
 
-// ── Mock posts for design stub ────────────────────────────────────────────────
-const MOCK_MY_POSTS = [
-  {
-    _id: "post-1",
-    type: "article",
-    author: { _id: "me", name: "You", avatar: "", reputation: 540 },
-    title: "Understanding React Server Components in Next.js 14",
-    content:
-      "Server Components allow you to render components on the server and stream them to the client. This fundamentally changes how we think about data fetching and bundle size...",
-    tags: ["react", "nextjs", "server-components"],
-    views: 214,
-    comments: 8,
-    createdAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString(),
-    reactions: { "🔥": ["u1", "u2", "u3"], "💡": ["u4"] },
-    pinned: false,
-  },
-  {
-    _id: "post-2",
-    type: "snippet",
-    author: { _id: "me", name: "You", avatar: "", reputation: 540 },
-    title: "Debounce hook with TypeScript generics",
-    content: "A clean, reusable debounce hook that preserves type inference.",
-    snippet: {
-      files: [
-        {
-          filename: "useDebounce.ts",
-          language: "typescript",
-          code: `import { useState, useEffect } from 'react';
-
-export function useDebounce<T>(value: T, delay: number): T {
-  const [debounced, setDebounced] = useState(value);
-  useEffect(() => {
-    const t = setTimeout(() => setDebounced(value), delay);
-    return () => clearTimeout(t);
-  }, [value, delay]);
-  return debounced;
-}`,
-        },
-      ],
-    },
-    tags: ["typescript", "hooks", "react"],
-    views: 87,
-    comments: 3,
-    createdAt: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString(),
-    reactions: { "🚀": ["u1"], "💡": ["u2", "u3"] },
-    pinned: false,
-  },
-  {
-    _id: "post-3",
-    type: "question",
-    author: { _id: "me", name: "You", avatar: "", reputation: 540 },
-    title: "Why does useEffect run twice in React 18 strict mode?",
-    content:
-      "I noticed my useEffect cleanup function firing on mount. Is this expected behavior or a bug in my setup?",
-    tags: ["react", "hooks", "debugging"],
-    views: 319,
-    comments: 12,
-    createdAt: new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString(),
-    reactions: { "🔥": ["u5"] },
-    status: "answered",
-    pinned: false,
-  },
-];
-
 // ── Main Page ───────────────────────────────────────────────────────────────
 function ProfilePage() {
   const { user, updateProfile, changePassword } = useAuth();
@@ -178,8 +116,46 @@ function ProfilePage() {
   // UI state
   const [savingProfile, setSavingProfile] = useState(false);
   const [savingPw, setSavingPw] = useState(false);
-  const [activeSection, setActiveSection] = useState("edit"); // "edit" | "security" | "posts"
+  const searchParams = useSearchParams();
+  const [activeSection, setActiveSection] = useState(
+    searchParams?.get("tab") === "posts" ? "posts" : "edit",
+  );
   const [activePost, setActivePost] = useState(null);
+
+  // ── My posts (real API) ───────────────────────────────────────────────
+  const [myPosts, setMyPosts] = useState([]);
+  const [myPostsLoading, setMyPostsLoading] = useState(false);
+  const [myPostsPage, setMyPostsPage] = useState(1);
+  const [myPostsHasMore, setMyPostsHasMore] = useState(false);
+
+  const loadMyPosts = useCallback(
+    async (page = 1) => {
+      const userId = user?._id || user?.id;
+      if (!userId) return;
+      setMyPostsLoading(true);
+      try {
+        const res = await api.get(`/api/feed/users/${userId}/posts`, {
+          params: { page, limit: 20 },
+        });
+        const incoming = res.data.posts || [];
+        if (page === 1) setMyPosts(incoming);
+        else setMyPosts((prev) => [...prev, ...incoming]);
+        setMyPostsHasMore(res.data.hasMore ?? false);
+      } catch (err) {
+        console.error("loadMyPosts error:", err.message);
+      } finally {
+        setMyPostsLoading(false);
+      }
+    },
+    [user],
+  );
+
+  useEffect(() => {
+    if (activeSection === "posts") {
+      setMyPostsPage(1);
+      loadMyPosts(1);
+    }
+  }, [activeSection, loadMyPosts]);
 
   // ── Avatar picker ─────────────────────────────────────────────────────
   const handleAvatarChange = (e) => {
@@ -545,12 +521,18 @@ function ProfilePage() {
                     <Rss size={10} className="text-accent/50" />
                     Published Posts
                     <span className="ml-1 px-1.5 py-0.5 rounded-full bg-accent/10 text-accent text-[9px] font-mono">
-                      {MOCK_MY_POSTS.length}
+                      {myPosts.length}
                     </span>
                   </h2>
                 </div>
 
-                {MOCK_MY_POSTS.length === 0 ? (
+                {myPostsLoading && myPosts.length === 0 ? (
+                  <div className="flex justify-center py-10">
+                    <span className="text-accent/40 text-[12px] font-mono animate-pulse">
+                      Loading posts...
+                    </span>
+                  </div>
+                ) : myPosts.length === 0 ? (
                   <div className="glass-card rounded-2xl border border-white/[0.08] p-10 flex flex-col items-center justify-center gap-3 text-center">
                     <Rss size={28} className="text-ivory/10" />
                     <p className="text-ivory/25 text-[13px] font-mono">
@@ -563,29 +545,32 @@ function ProfilePage() {
                   </div>
                 ) : (
                   <div className="space-y-3">
-                    {MOCK_MY_POSTS.map((post) => (
+                    {myPosts.map((post) => (
                       <PostCard
                         key={post._id}
                         post={post}
                         currentUserId={user?._id || user?.id || "me"}
                         onOpen={() => setActivePost(post)}
-                        onReact={() => {
-                          /* TODO */
-                        }}
-                        onShare={() => {
-                          /* TODO */
-                        }}
-                        onTagClick={() => {
-                          /* TODO */
-                        }}
-                        onEdit={() => {
-                          /* TODO */
-                        }}
-                        onDelete={() => {
-                          /* TODO */
-                        }}
+                        onReact={() => {}}
+                        onShare={() => {}}
+                        onTagClick={() => {}}
+                        onEdit={() => {}}
+                        onDelete={() => {}}
                       />
                     ))}
+                    {myPostsHasMore && (
+                      <button
+                        onClick={() => {
+                          const next = myPostsPage + 1;
+                          setMyPostsPage(next);
+                          loadMyPosts(next);
+                        }}
+                        disabled={myPostsLoading}
+                        className="w-full py-2 text-[11px] font-mono text-ivory/25 hover:text-ivory/50 transition-colors"
+                      >
+                        {myPostsLoading ? "Loading..." : "Load more"}
+                      </button>
+                    )}
                   </div>
                 )}
               </div>

--- a/src/app/(site)/profile/page.jsx
+++ b/src/app/(site)/profile/page.jsx
@@ -134,7 +134,7 @@ function ProfilePage() {
   const loadMyPosts = useCallback(
     async (page = 1) => {
       const userId = user?._id || user?.id;
-      if (!userId) return;
+      if (!userId) return false;
       setMyPostsLoading(true);
       setMyPostsError(false);
       try {
@@ -146,9 +146,11 @@ function ProfilePage() {
         else setMyPosts((prev) => [...prev, ...incoming]);
         setMyPostsHasMore(res.data.hasMore ?? false);
         setMyPostsLoaded(true);
+        return true;
       } catch (err) {
         console.error("loadMyPosts error:", err.message);
         setMyPostsError(true);
+        return false;
       } finally {
         setMyPostsLoading(false);
       }
@@ -580,8 +582,8 @@ function ProfilePage() {
                       <button
                         onClick={async () => {
                           const next = myPostsPage + 1;
-                          await loadMyPosts(next);
-                          setMyPostsPage(next);
+                          const ok = await loadMyPosts(next);
+                          if (ok) setMyPostsPage(next);
                         }}
                         disabled={myPostsLoading}
                         className="w-full py-2 text-[11px] font-mono text-ivory/25 hover:text-ivory/50 transition-colors"

--- a/src/app/(site)/profile/page.jsx
+++ b/src/app/(site)/profile/page.jsx
@@ -128,11 +128,15 @@ function ProfilePage() {
   const [myPostsPage, setMyPostsPage] = useState(1);
   const [myPostsHasMore, setMyPostsHasMore] = useState(false);
 
+  const [myPostsError, setMyPostsError] = useState(false);
+  const [myPostsLoaded, setMyPostsLoaded] = useState(false);
+
   const loadMyPosts = useCallback(
     async (page = 1) => {
       const userId = user?._id || user?.id;
       if (!userId) return;
       setMyPostsLoading(true);
+      setMyPostsError(false);
       try {
         const res = await api.get(`/api/feed/users/${userId}/posts`, {
           params: { page, limit: 20 },
@@ -141,8 +145,10 @@ function ProfilePage() {
         if (page === 1) setMyPosts(incoming);
         else setMyPosts((prev) => [...prev, ...incoming]);
         setMyPostsHasMore(res.data.hasMore ?? false);
+        setMyPostsLoaded(true);
       } catch (err) {
         console.error("loadMyPosts error:", err.message);
+        setMyPostsError(true);
       } finally {
         setMyPostsLoading(false);
       }
@@ -532,7 +538,19 @@ function ProfilePage() {
                       Loading posts...
                     </span>
                   </div>
-                ) : myPosts.length === 0 ? (
+                ) : myPostsError ? (
+                  <div className="glass-card rounded-2xl border border-white/[0.08] p-10 flex flex-col items-center justify-center gap-3 text-center">
+                    <p className="text-red-400/50 text-[13px] font-mono">
+                      Failed to load posts
+                    </p>
+                    <button
+                      onClick={() => loadMyPosts(1)}
+                      className="text-accent text-[12px] font-mono hover:underline"
+                    >
+                      Try again
+                    </button>
+                  </div>
+                ) : myPostsLoaded && myPosts.length === 0 ? (
                   <div className="glass-card rounded-2xl border border-white/[0.08] p-10 flex flex-col items-center justify-center gap-3 text-center">
                     <Rss size={28} className="text-ivory/10" />
                     <p className="text-ivory/25 text-[13px] font-mono">
@@ -560,10 +578,10 @@ function ProfilePage() {
                     ))}
                     {myPostsHasMore && (
                       <button
-                        onClick={() => {
+                        onClick={async () => {
                           const next = myPostsPage + 1;
+                          await loadMyPosts(next);
                           setMyPostsPage(next);
-                          loadMyPosts(next);
                         }}
                         disabled={myPostsLoading}
                         className="w-full py-2 text-[11px] font-mono text-ivory/25 hover:text-ivory/50 transition-colors"

--- a/src/components/Feed/FeedSidebar.jsx
+++ b/src/components/Feed/FeedSidebar.jsx
@@ -120,7 +120,7 @@ export default function FeedSidebar({
         {/* ── Navigation ── */}
         <nav className="flex flex-col gap-0.5 px-3 py-3 border-b border-white/[0.06]">
           {[
-            { href: "/profile", icon: FileText, label: "My Posts" },
+            { href: "/profile?tab=posts", icon: FileText, label: "My Posts" },
             {
               href: "/app/feed?view=following",
               icon: Tag,

--- a/src/components/Feed/FeedSidebar.jsx
+++ b/src/components/Feed/FeedSidebar.jsx
@@ -72,17 +72,19 @@ export default function FeedSidebar({
   onTagFilter,
 }) {
   if (side === "left") {
-    const repLabel =
-      (userStats.reputation ?? 2500) >= 1000
-        ? `${((userStats.reputation ?? 2500) / 1000).toFixed(1)}k`
-        : String(userStats.reputation ?? 2500);
+    const rep = userStats.reputation ?? 0;
+    const repLabel = rep >= 1000 ? `${(rep / 1000).toFixed(1)}k` : String(rep);
     return (
       <aside className="w-full h-full flex flex-col overflow-y-auto scrollbar-hide">
         {/* ── User card ── */}
         <div className="flex flex-col items-center gap-3 px-5 pt-6 pb-5 border-b border-white/[0.06]">
           <div className="w-16 h-16 rounded-full overflow-hidden ring-2 ring-accent/30 bg-deep shrink-0">
             <Image
-              src={`https://api.dicebear.com/7.x/avataaars/svg?seed=${userStats.name || "Alex"}`}
+              src={
+                userStats.avatar
+                  ? userStats.avatar
+                  : `https://api.dicebear.com/7.x/avataaars/svg?seed=${userStats.name || "user"}`
+              }
               alt="avatar"
               width={64}
               height={64}
@@ -92,7 +94,7 @@ export default function FeedSidebar({
           </div>
           <div className="text-center">
             <p className="font-display font-bold text-ivory text-[15px] leading-tight">
-              {userStats.name || "Alex Rivera"}
+              {userStats.name || "You"}
             </p>
             <span className="inline-block mt-1.5 text-[10px] font-mono font-bold text-accent bg-accent/10 border border-accent/20 px-2.5 py-0.5 rounded-full">
               REP: {repLabel}
@@ -101,9 +103,9 @@ export default function FeedSidebar({
           {/* Stats row */}
           <div className="flex items-center justify-around w-full pt-3 border-t border-white/[0.06]">
             {[
-              { label: "FANS", value: userStats.followersCount ?? "1.2k" },
-              { label: "FOLLOWING", value: userStats.followingCount ?? "850" },
-              { label: "POSTS", value: userStats.postCount ?? "42" },
+              { label: "FANS", value: userStats.followersCount ?? 0 },
+              { label: "FOLLOWING", value: userStats.followingCount ?? 0 },
+              { label: "POSTS", value: userStats.postCount ?? 0 },
             ].map(({ label, value }) => (
               <div key={label} className="flex flex-col items-center gap-0.5">
                 <span className="font-display font-bold text-ivory text-[15px] leading-tight">

--- a/src/components/Feed/UserCard.jsx
+++ b/src/components/Feed/UserCard.jsx
@@ -25,12 +25,18 @@ export default function UserCard({
 }) {
   const { followUser, followingSet } = useFeed();
 
-  // followingSet from context takes priority, then prop
   const contextFollowing = user._id ? followingSet?.has(user._id) : undefined;
   const [followed, setFollowed] = useState(
     contextFollowing ?? legacyFollowing ?? initialFollowing,
   );
   const [loading, setLoading] = useState(false);
+
+  // Keep in sync when followingSet changes (e.g. toggled from another card)
+  useEffect(() => {
+    if (user._id && followingSet) {
+      setFollowed(followingSet.has(user._id));
+    }
+  }, [followingSet, user._id]);
 
   const handleFollow = async (e) => {
     e.preventDefault();

--- a/src/components/Feed/UserCard.jsx
+++ b/src/components/Feed/UserCard.jsx
@@ -18,25 +18,37 @@ import toast from "react-hot-toast";
  */
 export default function UserCard({
   user = {},
-  isFollowing: initialFollowing = false,
+  isFollowing: initialFollowing,
   following: legacyFollowing, // backwards compat
   isCurrentUser = false,
   variant = "inline",
 }) {
   const { followUser, followingSet } = useFeed();
 
+  // Explicit props win; fall back to followingSet only if props are undefined
   const contextFollowing = user._id ? followingSet?.has(user._id) : undefined;
-  const [followed, setFollowed] = useState(
-    contextFollowing ?? legacyFollowing ?? initialFollowing,
-  );
+  const resolvedFollowing =
+    initialFollowing !== undefined
+      ? initialFollowing
+      : legacyFollowing !== undefined
+        ? legacyFollowing
+        : (contextFollowing ?? false);
+
+  const [followed, setFollowed] = useState(resolvedFollowing);
   const [loading, setLoading] = useState(false);
 
-  // Keep in sync when followingSet changes (e.g. toggled from another card)
+  // Sync with followingSet only when not loading and no explicit prop provided
   useEffect(() => {
-    if (user._id && followingSet) {
-      setFollowed(followingSet.has(user._id));
+    if (
+      !loading &&
+      initialFollowing === undefined &&
+      legacyFollowing === undefined
+    ) {
+      if (user._id && followingSet) {
+        setFollowed(followingSet.has(user._id));
+      }
     }
-  }, [followingSet, user._id]);
+  }, [followingSet, user._id, loading, initialFollowing, legacyFollowing]);
 
   const handleFollow = async (e) => {
     e.preventDefault();

--- a/src/components/Feed/UserCard.jsx
+++ b/src/components/Feed/UserCard.jsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { UserPlus, UserCheck, Loader2 } from "lucide-react";

--- a/src/components/Feed/UserCard.jsx
+++ b/src/components/Feed/UserCard.jsx
@@ -3,32 +3,55 @@
 import { useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
-import { UserPlus, UserCheck, MessageCircle } from "lucide-react";
+import { UserPlus, UserCheck, Loader2 } from "lucide-react";
 import ReputationBadge from "./ReputationBadge";
+import useFeed from "@/hooks/useFeed";
+import toast from "react-hot-toast";
 
 /**
  * UserCard — compact author info card.
- * Used inline in PostCard (hover) and standalone in sidebars.
  *
  * @param {object}  user          - { _id, name, avatar, reputation, bio }
- * @param {boolean} following     - whether the current viewer follows this user
+ * @param {boolean} isFollowing   - initial follow state from parent
  * @param {boolean} isCurrentUser - hide follow button for own card
  * @param {"inline"|"panel"} variant
  */
 export default function UserCard({
   user = {},
-  following = false,
+  isFollowing: initialFollowing = false,
+  following: legacyFollowing, // backwards compat
   isCurrentUser = false,
   variant = "inline",
 }) {
-  const [followed, setFollowed] = useState(following);
+  const { followUser, followingSet } = useFeed();
 
-  // Design-only toggle — TODO wire to followUser()
-  const handleFollow = (e) => {
+  // followingSet from context takes priority, then prop
+  const contextFollowing = user._id ? followingSet?.has(user._id) : undefined;
+  const [followed, setFollowed] = useState(
+    contextFollowing ?? legacyFollowing ?? initialFollowing,
+  );
+  const [loading, setLoading] = useState(false);
+
+  const handleFollow = async (e) => {
     e.preventDefault();
-    setFollowed((f) => !f);
+    e.stopPropagation();
+    if (loading || !user._id) return;
+
+    setLoading(true);
+    const prev = followed;
+    setFollowed(!prev); // optimistic
+
+    try {
+      await followUser(user._id);
+    } catch {
+      setFollowed(prev); // revert
+      toast.error("Could not update follow status");
+    } finally {
+      setLoading(false);
+    }
   };
 
+  // ── Panel variant ───────────────────────────────────────────────────────────
   if (variant === "panel") {
     return (
       <div className="flex items-start gap-3 p-3 rounded-2xl bg-white/[0.04] ring-1 ring-white/[0.07]">
@@ -60,21 +83,30 @@ export default function UserCard({
             </Link>
             <ReputationBadge reputation={user.reputation ?? 0} size="sm" />
           </div>
+
           {user.bio && (
             <p className="text-[11px] text-ivory/40 mt-0.5 line-clamp-1">
               {user.bio}
             </p>
           )}
+
           {!isCurrentUser && (
             <button
               onClick={handleFollow}
-              className={`mt-2 flex items-center gap-1 text-[11px] font-mono font-bold uppercase tracking-wider px-2 py-0.5 rounded-lg transition-all duration-200 ${
+              disabled={loading}
+              className={`mt-2 flex items-center gap-1 text-[11px] font-mono font-bold uppercase tracking-wider px-2 py-0.5 rounded-lg transition-all duration-200 disabled:opacity-50 ${
                 followed
                   ? "text-accent/70 bg-accent/8 hover:bg-accent/12"
                   : "text-ivory/40 bg-white/[0.05] hover:text-accent hover:bg-accent/8"
               }`}
             >
-              {followed ? <UserCheck size={11} /> : <UserPlus size={11} />}
+              {loading ? (
+                <Loader2 size={11} className="animate-spin" />
+              ) : followed ? (
+                <UserCheck size={11} />
+              ) : (
+                <UserPlus size={11} />
+              )}
               {followed ? "Following" : "Follow"}
             </button>
           )}
@@ -83,7 +115,7 @@ export default function UserCard({
     );
   }
 
-  // Inline variant — compact row (used in post headers)
+  // ── Inline variant ──────────────────────────────────────────────────────────
   return (
     <Link
       href={`/profile/${user._id}`}

--- a/src/context/FeedProvider.jsx
+++ b/src/context/FeedProvider.jsx
@@ -402,8 +402,9 @@ export function FeedProvider({ children }) {
   );
 
   const getUserProfile = useCallback(
-    async (userId) => {
-      if (profileCache[userId]) return profileCache[userId];
+    async (userId, { forceRefresh = false } = {}) => {
+      // Return cache only if not forcing refresh
+      if (!forceRefresh && profileCache[userId]) return profileCache[userId];
       try {
         const res = await api.get(`/api/feed/users/${userId}/profile`);
         const profile = res.data;
@@ -413,6 +414,8 @@ export function FeedProvider({ children }) {
         }
         return profile;
       } catch (error) {
+        // On error, return cached version if available
+        if (profileCache[userId]) return profileCache[userId];
         console.error(
           "getUserProfile error:",
           error?.response?.data?.message || error.message,

--- a/src/context/FeedProvider.jsx
+++ b/src/context/FeedProvider.jsx
@@ -4,6 +4,7 @@ import { useState, useCallback, useContext, useEffect } from "react";
 import { SocketContext } from "./SocketContext";
 import { FeedContext } from "./FeedContext";
 import api from "@/app/api/Axios";
+import useAuth from "@/hooks/useAuth";
 
 export function FeedProvider({ children }) {
   // ── Feed state ─────────────────────────────────────────────────────────────
@@ -31,6 +32,7 @@ export function FeedProvider({ children }) {
   const [followingSet, setFollowingSet] = useState(new Set());
   const [profileCache, setProfileCache] = useState({});
 
+  const { user: authUser } = useAuth();
   const socketCtx = useContext(SocketContext);
   const socket = socketCtx?.socket ?? null;
 
@@ -114,6 +116,11 @@ export function FeedProvider({ children }) {
         postCount: res.data.postCount ?? 0,
         level: res.data.level ?? "Newcomer",
         badge: res.data.badge ?? "🟢",
+        followersCount: res.data.followersCount ?? 0,
+        followingCount: res.data.followingCount ?? 0,
+        name: res.data.name ?? authUser?.name ?? "",
+        avatar: res.data.avatar ?? authUser?.avatar ?? "",
+        _id: res.data._id ?? userId,
       });
     } catch (error) {
       // silently fail — stats not critical

--- a/src/context/FeedProvider.jsx
+++ b/src/context/FeedProvider.jsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useContext, useEffect } from "react";
+import { useState, useCallback, useContext, useEffect, useRef } from "react";
 import { SocketContext } from "./SocketContext";
 import { FeedContext } from "./FeedContext";
 import api from "@/app/api/Axios";
@@ -39,6 +39,12 @@ export function FeedProvider({ children }) {
   // ── Social state ───────────────────────────────────────────────────────────
   const [followingSet, setFollowingSet] = useState(new Set());
   const [profileCache, setProfileCache] = useState({});
+  const profileCacheRef = useRef({});
+
+  // Keep ref in sync with state for stable reads inside callbacks
+  useEffect(() => {
+    profileCacheRef.current = profileCache;
+  }, [profileCache]);
 
   const socketCtx = useContext(SocketContext);
   const socket = socketCtx?.socket ?? null;
@@ -403,19 +409,30 @@ export function FeedProvider({ children }) {
 
   const getUserProfile = useCallback(
     async (userId, { forceRefresh = false } = {}) => {
-      // Return cache only if not forcing refresh
-      if (!forceRefresh && profileCache[userId]) return profileCache[userId];
+      // Use ref for stable cache reads — avoids recreating callback on every cache write
+      if (!forceRefresh && profileCacheRef.current[userId]) {
+        return profileCacheRef.current[userId];
+      }
       try {
         const res = await api.get(`/api/feed/users/${userId}/profile`);
         const profile = res.data;
+        profileCacheRef.current = {
+          ...profileCacheRef.current,
+          [userId]: profile,
+        };
         setProfileCache((prev) => ({ ...prev, [userId]: profile }));
-        if (profile.isFollowing) {
-          setFollowingSet((prev) => new Set([...prev, userId]));
-        }
+        // Sync followingSet for both true and false states
+        setFollowingSet((prev) => {
+          const next = new Set(prev);
+          if (profile.isFollowing) next.add(userId);
+          else next.delete(userId);
+          return next;
+        });
         return profile;
       } catch (error) {
         // On error, return cached version if available
-        if (profileCache[userId]) return profileCache[userId];
+        if (profileCacheRef.current[userId])
+          return profileCacheRef.current[userId];
         console.error(
           "getUserProfile error:",
           error?.response?.data?.message || error.message,
@@ -423,7 +440,7 @@ export function FeedProvider({ children }) {
         throw error;
       }
     },
-    [profileCache],
+    [], // stable — reads cache via ref, not state
   );
 
   const getUserPosts = useCallback(async (userId, page = 1, limit = 20) => {

--- a/src/context/FeedProvider.jsx
+++ b/src/context/FeedProvider.jsx
@@ -352,6 +352,15 @@ export function FeedProvider({ children }) {
         };
       });
 
+      // Update own followingCount in sidebar
+      setUserStats((prev) => ({
+        ...prev,
+        followingCount: Math.max(
+          0,
+          (prev.followingCount ?? 0) + (wasFollowing ? -1 : 1),
+        ),
+      }));
+
       try {
         const res = await api.post(`/api/feed/users/${userId}/follow`);
         return res.data;
@@ -374,6 +383,14 @@ export function FeedProvider({ children }) {
             },
           };
         });
+        // Revert own followingCount
+        setUserStats((prev) => ({
+          ...prev,
+          followingCount: Math.max(
+            0,
+            (prev.followingCount ?? 0) + (wasFollowing ? 1 : -1),
+          ),
+        }));
         console.error(
           "followUser error:",
           error?.response?.data?.message || error.message,

--- a/src/context/FeedProvider.jsx
+++ b/src/context/FeedProvider.jsx
@@ -21,18 +21,25 @@ export function FeedProvider({ children }) {
   const [composerOpen, setComposerOpen] = useState(false);
   const [selectedPost, setSelectedPost] = useState(null);
   const [shareTarget, setShareTarget] = useState(null);
-  const [userStats, setUserStats] = useState({
+  const { user: authUser } = useAuth();
+
+  const [userStats, setUserStats] = useState(() => ({
     reputation: 0,
     level: "Newcomer",
     badge: "🟢",
     postCount: 0,
-  });
+    followersCount: 0,
+    followingCount: 0,
+    followedTags: [],
+    name: "",
+    avatar: "",
+    _id: "",
+  }));
 
   // ── Social state ───────────────────────────────────────────────────────────
   const [followingSet, setFollowingSet] = useState(new Set());
   const [profileCache, setProfileCache] = useState({});
 
-  const { user: authUser } = useAuth();
   const socketCtx = useContext(SocketContext);
   const socket = socketCtx?.socket ?? null;
 
@@ -118,6 +125,7 @@ export function FeedProvider({ children }) {
         badge: res.data.badge ?? "🟢",
         followersCount: res.data.followersCount ?? 0,
         followingCount: res.data.followingCount ?? 0,
+        followedTags: res.data.followedTags ?? [],
         name: res.data.name ?? authUser?.name ?? "",
         avatar: res.data.avatar ?? authUser?.avatar ?? "",
         _id: res.data._id ?? userId,
@@ -444,7 +452,7 @@ export function FeedProvider({ children }) {
     shareTarget,
     setShareTarget,
     userStats,
-    followedTags: [],
+    followedTags: userStats.followedTags ?? [],
     fetchMyStats,
     // Social state
     followingSet,

--- a/src/context/FeedProvider.jsx
+++ b/src/context/FeedProvider.jsx
@@ -5,11 +5,10 @@ import { SocketContext } from "./SocketContext";
 import { FeedContext } from "./FeedContext";
 import api from "@/app/api/Axios";
 
-
 export function FeedProvider({ children }) {
   // ── Feed state ─────────────────────────────────────────────────────────────
   const [posts, setPosts] = useState([]);
-  const [activeTab, setActiveTab] = useState("latest"); // latest | trending | top | following | qa
+  const [activeTab, setActiveTab] = useState("latest");
   const [filters, setFilters] = useState({
     type: "all",
     tags: [],
@@ -19,8 +18,8 @@ export function FeedProvider({ children }) {
   const [hasMore, setHasMore] = useState(true);
   const [loading, setLoading] = useState(false);
   const [composerOpen, setComposerOpen] = useState(false);
-  const [selectedPost, setSelectedPost] = useState(null); // post detail view
-  const [shareTarget, setShareTarget] = useState(null); // post being shared
+  const [selectedPost, setSelectedPost] = useState(null);
+  const [shareTarget, setShareTarget] = useState(null);
   const [userStats, setUserStats] = useState({
     reputation: 0,
     level: "Newcomer",
@@ -28,41 +27,37 @@ export function FeedProvider({ children }) {
     postCount: 0,
   });
 
+  // ── Social state ───────────────────────────────────────────────────────────
+  const [followingSet, setFollowingSet] = useState(new Set());
+  const [profileCache, setProfileCache] = useState({});
+
   const socketCtx = useContext(SocketContext);
   const socket = socketCtx?.socket ?? null;
 
   const normalizePost = useCallback((post) => {
     if (!post || typeof post !== "object") return post;
-    if (post.id && !post._id) {
-      return { ...post, _id: post.id };
-    }
+    if (post.id && !post._id) return { ...post, _id: post.id };
     return post;
   }, []);
 
   const mergePosts = useCallback(
     (existing, incoming) => {
       const map = new Map();
-
       for (const post of existing) {
-        const normalized = normalizePost(post);
-        if (normalized?._id) {
-          map.set(normalized._id, normalized);
-        }
+        const n = normalizePost(post);
+        if (n?._id) map.set(n._id, n);
       }
-
       for (const post of incoming) {
-        const normalized = normalizePost(post);
-        if (normalized?._id) {
-          map.set(normalized._id, normalized);
-        }
+        const n = normalizePost(post);
+        if (n?._id) map.set(n._id, n);
       }
-
       return Array.from(map.values());
     },
     [normalizePost],
   );
 
-  // ── Feed API actions ────────────────────────────────────────────────────────
+  // ── Feed API ────────────────────────────────────────────────────────────────
+
   const fetchPosts = useCallback(async () => {
     setLoading(true);
     try {
@@ -96,9 +91,7 @@ export function FeedProvider({ children }) {
         "fetchPosts error:",
         error?.response?.data?.message || error.message,
       );
-      if (page === 1) {
-        setPosts([]);
-      }
+      if (page === 1) setPosts([]);
       setHasMore(false);
     } finally {
       setLoading(false);
@@ -107,10 +100,23 @@ export function FeedProvider({ children }) {
 
   const fetchMyStats = useCallback(async () => {
     try {
-      const response = await api.get("/api/feed/me/stats");
-      setUserStats(response.data);
+      const userId = (() => {
+        const token = localStorage.getItem("token");
+        if (!token) return null;
+        const b64 = token.split(".")[1].replace(/-/g, "+").replace(/_/g, "/");
+        const payload = JSON.parse(atob(b64));
+        return payload.id ?? payload._id ?? null;
+      })();
+      if (!userId) return;
+      const res = await api.get(`/api/feed/users/${userId}/profile`);
+      setUserStats({
+        reputation: res.data.reputation ?? 0,
+        postCount: res.data.postCount ?? 0,
+        level: res.data.level ?? "Newcomer",
+        badge: res.data.badge ?? "🟢",
+      });
     } catch (error) {
-      console.error("fetchMyStats error:", error?.response?.data?.message || error.message);
+      // silently fail — stats not critical
     }
   }, []);
 
@@ -120,7 +126,6 @@ export function FeedProvider({ children }) {
 
   useEffect(() => {
     if (!socket) return;
-
     const handleReacted = ({ postId, reactions, reactionCount }) => {
       setPosts((prev) =>
         prev.map((p) =>
@@ -128,7 +133,6 @@ export function FeedProvider({ children }) {
         ),
       );
     };
-
     socket.on("feed:post:reacted", handleReacted);
     return () => socket.off("feed:post:reacted", handleReacted);
   }, [socket]);
@@ -139,31 +143,21 @@ export function FeedProvider({ children }) {
       const optimisticPost = {
         _id: tempId,
         ...payload,
-        author: {
-          _id: "me",
-          name: "You",
-          avatar: "",
-        },
+        author: { _id: "me", name: "You", avatar: "" },
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
         commentsCount: 0,
         reactions: {},
         reactionCount: 0,
       };
-
       setPosts((prev) => [optimisticPost, ...prev]);
-
       try {
         const response = await api.post("/api/feed/posts", payload);
         const created = normalizePost(response.data);
-
-        setPosts((prev) =>
-          prev.map((post) => (post._id === tempId ? created : post)),
-        );
-
+        setPosts((prev) => prev.map((p) => (p._id === tempId ? created : p)));
         return created;
       } catch (error) {
-        setPosts((prev) => prev.filter((post) => post._id !== tempId));
+        setPosts((prev) => prev.filter((p) => p._id !== tempId));
         console.error(
           "createPost error:",
           error?.response?.data?.message || error.message,
@@ -177,32 +171,22 @@ export function FeedProvider({ children }) {
   const editPost = useCallback(
     async (id, payload) => {
       let previousPost = null;
-
       setPosts((prev) =>
         prev.map((post) => {
           if (post._id !== id) return post;
           previousPost = post;
-          return {
-            ...post,
-            ...payload,
-            updatedAt: new Date().toISOString(),
-          };
+          return { ...post, ...payload, updatedAt: new Date().toISOString() };
         }),
       );
-
       try {
         const response = await api.patch(`/api/feed/posts/${id}`, payload);
         const updated = normalizePost(response.data);
-
-        setPosts((prev) =>
-          prev.map((post) => (post._id === id ? updated : post)),
-        );
-
+        setPosts((prev) => prev.map((p) => (p._id === id ? updated : p)));
         return updated;
       } catch (error) {
         if (previousPost) {
           setPosts((prev) =>
-            prev.map((post) => (post._id === id ? previousPost : post)),
+            prev.map((p) => (p._id === id ? previousPost : p)),
           );
         }
         console.error(
@@ -217,26 +201,19 @@ export function FeedProvider({ children }) {
 
   const deletePost = useCallback(async (id) => {
     let deletedPost = null;
-
     setPosts((prev) => {
       const next = [];
       for (const post of prev) {
-        if (post._id === id) {
-          deletedPost = post;
-        } else {
-          next.push(post);
-        }
+        if (post._id === id) deletedPost = post;
+        else next.push(post);
       }
       return next;
     });
-
     try {
       await api.delete(`/api/feed/posts/${id}`);
       return true;
     } catch (error) {
-      if (deletedPost) {
-        setPosts((prev) => [deletedPost, ...prev]);
-      }
+      if (deletedPost) setPosts((prev) => [deletedPost, ...prev]);
       console.error(
         "deletePost error:",
         error?.response?.data?.message || error.message,
@@ -247,13 +224,11 @@ export function FeedProvider({ children }) {
 
   const reactToPost = useCallback(
     async (id, emoji) => {
-      // Snapshot for rollback
       let snapshot = null;
       const currentUserId = (() => {
         try {
           const token = localStorage.getItem("token");
           if (!token) return null;
-          // JWT uses base64url (- and _ instead of + and /); atob needs standard base64
           const b64 = token.split(".")[1].replace(/-/g, "+").replace(/_/g, "/");
           const payload = JSON.parse(atob(b64));
           return payload.id ?? payload._id ?? null;
@@ -262,90 +237,190 @@ export function FeedProvider({ children }) {
         }
       })();
 
-      // Optimistic update
       setPosts((prev) =>
         prev.map((p) => {
           if (p._id !== id) return p;
           snapshot = p;
-
           const existing = Array.isArray(p.reactions?.[emoji])
             ? p.reactions[emoji]
             : [];
-          const alreadyReacted = currentUserId && existing.includes(currentUserId);
-
+          const alreadyReacted =
+            currentUserId && existing.includes(currentUserId);
           const updated = alreadyReacted
             ? existing.filter((uid) => uid !== currentUserId)
             : currentUserId
-            ? [...existing, currentUserId]
-            : existing;
-
-          const countDelta = alreadyReacted ? -1 : 1;
-
+              ? [...existing, currentUserId]
+              : existing;
           return {
             ...p,
             reactions: { ...(p.reactions ?? {}), [emoji]: updated },
-            reactionCount: Math.max(0, (p.reactionCount ?? 0) + countDelta),
+            reactionCount: Math.max(
+              0,
+              (p.reactionCount ?? 0) + (alreadyReacted ? -1 : 1),
+            ),
           };
         }),
       );
 
       try {
-        const response = await api.post(`/api/feed/posts/${id}/react`, { emoji });
-        // Sync with server truth
+        const response = await api.post(`/api/feed/posts/${id}/react`, {
+          emoji,
+        });
         setPosts((prev) =>
           prev.map((p) =>
             p._id === id
-              ? { ...p, reactions: response.data.reactions, reactionCount: response.data.reactionCount }
+              ? {
+                  ...p,
+                  reactions: response.data.reactions,
+                  reactionCount: response.data.reactionCount,
+                }
               : p,
           ),
         );
         await fetchMyStats();
       } catch (error) {
-        // Full rollback — restore entire post object, not just reaction fields
-        if (snapshot) {
+        if (snapshot)
           setPosts((prev) => prev.map((p) => (p._id === id ? snapshot : p)));
-        }
-        console.error("reactToPost error:", error?.response?.data?.message || error.message);
+        console.error(
+          "reactToPost error:",
+          error?.response?.data?.message || error.message,
+        );
       }
     },
     [fetchMyStats],
   );
 
-  const voteOnPoll = useCallback(async (postId, optionIndex) => {
-    // TODO: POST /api/feed/posts/:id/vote { optionIndex }
+  const voteOnPoll = useCallback(async () => {
+    /* TODO */
+  }, []);
+  const acceptAnswer = useCallback(async () => {
+    /* TODO */
+  }, []);
+  const fetchComments = useCallback(async () => {
+    /* TODO */
+  }, []);
+  const addComment = useCallback(async () => {
+    /* TODO */
+  }, []);
+  const reactToComment = useCallback(async () => {
+    /* TODO */
+  }, []);
+  const followTag = useCallback(async () => {
+    /* TODO */
+  }, []);
+  const searchPosts = useCallback(async () => {
+    /* TODO */
   }, []);
 
-  const acceptAnswer = useCallback(async (postId, commentId) => {
-    // TODO: POST /api/feed/posts/:id/accept/:commentId
+  // ── Social actions ─────────────────────────────────────────────────────────
+
+  const followUser = useCallback(
+    async (userId) => {
+      const wasFollowing = followingSet.has(userId);
+
+      // Optimistic update
+      setFollowingSet((prev) => {
+        const next = new Set(prev);
+        wasFollowing ? next.delete(userId) : next.add(userId);
+        return next;
+      });
+      setProfileCache((prev) => {
+        if (!prev[userId]) return prev;
+        return {
+          ...prev,
+          [userId]: {
+            ...prev[userId],
+            followersCount:
+              (prev[userId].followersCount ?? 0) + (wasFollowing ? -1 : 1),
+            isFollowing: !wasFollowing,
+          },
+        };
+      });
+
+      try {
+        const res = await api.post(`/api/feed/users/${userId}/follow`);
+        return res.data;
+      } catch (error) {
+        // Revert on error
+        setFollowingSet((prev) => {
+          const next = new Set(prev);
+          wasFollowing ? next.add(userId) : next.delete(userId);
+          return next;
+        });
+        setProfileCache((prev) => {
+          if (!prev[userId]) return prev;
+          return {
+            ...prev,
+            [userId]: {
+              ...prev[userId],
+              followersCount:
+                (prev[userId].followersCount ?? 0) + (wasFollowing ? 1 : -1),
+              isFollowing: wasFollowing,
+            },
+          };
+        });
+        console.error(
+          "followUser error:",
+          error?.response?.data?.message || error.message,
+        );
+        throw error;
+      }
+    },
+    [followingSet],
+  );
+
+  const getUserProfile = useCallback(
+    async (userId) => {
+      if (profileCache[userId]) return profileCache[userId];
+      try {
+        const res = await api.get(`/api/feed/users/${userId}/profile`);
+        const profile = res.data;
+        setProfileCache((prev) => ({ ...prev, [userId]: profile }));
+        if (profile.isFollowing) {
+          setFollowingSet((prev) => new Set([...prev, userId]));
+        }
+        return profile;
+      } catch (error) {
+        console.error(
+          "getUserProfile error:",
+          error?.response?.data?.message || error.message,
+        );
+        throw error;
+      }
+    },
+    [profileCache],
+  );
+
+  const getUserPosts = useCallback(async (userId, page = 1, limit = 20) => {
+    try {
+      const res = await api.get(`/api/feed/users/${userId}/posts`, {
+        params: { page, limit },
+      });
+      return res.data;
+    } catch (error) {
+      console.error(
+        "getUserPosts error:",
+        error?.response?.data?.message || error.message,
+      );
+      throw error;
+    }
   }, []);
 
-  const fetchComments = useCallback(async (postId) => {
-    // TODO: GET /api/feed/posts/:id/comments
-  }, []);
-
-  const addComment = useCallback(async (postId, payload) => {
-    // TODO: POST /api/feed/posts/:id/comments
-  }, []);
-
-  const reactToComment = useCallback(async (postId, commentId, emoji) => {
-    // TODO: POST /api/feed/posts/:id/comments/:commentId/react
-  }, []);
-
-  const followUser = useCallback(async (userId) => {
-    // TODO: POST /api/feed/users/:id/follow
-  }, []);
-
-  const followTag = useCallback(async (tag) => {
-    // TODO: POST /api/feed/tags/follow { tag }
-  }, []);
-
-  const searchPosts = useCallback(async (query, opts) => {
-    // TODO: GET /api/feed/search?q=&type=&tags=&sort=
+  const getTopContributors = useCallback(async () => {
+    try {
+      const res = await api.get("/api/feed/users/top-contributors");
+      return res.data;
+    } catch (error) {
+      console.error(
+        "getTopContributors error:",
+        error?.response?.data?.message || error.message,
+      );
+      throw error;
+    }
   }, []);
 
   // ── Context value ──────────────────────────────────────────────────────────
   const value = {
-    // State
     posts,
     activeTab,
     setActiveTab,
@@ -364,7 +439,10 @@ export function FeedProvider({ children }) {
     userStats,
     followedTags: [],
     fetchMyStats,
-    // Actions
+    // Social state
+    followingSet,
+    profileCache,
+    // Feed actions
     fetchPosts,
     createPost,
     editPost,
@@ -375,9 +453,13 @@ export function FeedProvider({ children }) {
     fetchComments,
     addComment,
     reactToComment,
-    followUser,
     followTag,
     searchPosts,
+    // Social actions
+    followUser,
+    getUserProfile,
+    getUserPosts,
+    getTopContributors,
   };
 
   return <FeedContext.Provider value={value}>{children}</FeedContext.Provider>;


### PR DESCRIPTION
Implements two complete features across server and client:

User Following — follow/unfollow any user, following feed tab, real-time follower counts
Public User Profiles — any authenticated user can view another user's profile, posts, reputation, and follow them

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live user profiles with real follower/following counts and reputation
  * Posts load dynamically with pagination and "Load more" controls
  * Follow/unfollow actions with immediate (optimistic) UI updates

* **Improvements**
  * Loading indicators for profile, posts, and follow actions
  * Follow button shows loading and followed/unfollowed states; toast feedback on errors
  * Navigation supports tab-specific URLs; Answers tab shows a placeholder for upcoming content
  * Sidebar defaults and avatar/name fallbacks improved
<!-- end of auto-generated comment: release notes by coderabbit.ai -->